### PR TITLE
Replaces hardcoded labels, annotations, and namespaces for all resources

### DIFF
--- a/operators/knative-controller/src/charm.py
+++ b/operators/knative-controller/src/charm.py
@@ -55,7 +55,7 @@ class Operator(CharmBase):
         )
 
         args = {"name": "controller", "namespace": self.model.name}
-        crds = Path("src/crds.yaml").read_text()
+        crds = env.get_template("crds.yaml.j2").render(**args)
         rbac = env.get_template("rbac.yaml.j2").render(**args)
         deployment = env.get_template("deployment.yaml.j2").render(**args)
         config = env.get_template("config.yaml.j2").render(**args)

--- a/operators/knative-controller/src/config.yaml.j2
+++ b/operators/knative-controller/src/config.yaml.j2
@@ -19,7 +19,7 @@ metadata:
   namespace: [[ namespace ]]
   labels:
     app.kubernetes.io/component: autoscaler
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
   annotations:
@@ -230,7 +230,7 @@ metadata:
   name: config-defaults
   namespace: [[ namespace ]]
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
@@ -374,7 +374,7 @@ metadata:
   name: config-deployment
   namespace: [[ namespace ]]
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
@@ -478,7 +478,7 @@ metadata:
   name: config-domain
   namespace: [[ namespace ]]
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
@@ -546,7 +546,7 @@ metadata:
   name: config-features
   namespace: [[ namespace ]]
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
@@ -699,7 +699,7 @@ metadata:
   name: config-gc
   namespace: [[ namespace ]]
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
@@ -800,7 +800,7 @@ metadata:
   name: config-leader-election
   namespace: [[ namespace ]]
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
@@ -865,7 +865,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
   annotations:
     knative.dev/example-checksum: "be93ff10"
 data:
@@ -942,7 +942,7 @@ metadata:
   name: config-network
   namespace: [[ namespace ]]
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
   annotations:
@@ -950,7 +950,7 @@ metadata:
 data:
   # FIXME: This needs to be configurable, see here for options:
   # https://knative.dev/v1.1-docs/install/serving/install-serving-with-yaml/#install-a-networking-layer
-  ingress-class: kourier.ingress.networking.knative.dev
+  #ingress-class: kourier.ingress.networking.knative.dev
   _example: |
     ################################
     #                              #
@@ -1121,7 +1121,7 @@ metadata:
   name: config-observability
   namespace: [[ namespace ]]
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
   annotations:
@@ -1230,7 +1230,7 @@ metadata:
   name: config-tracing
   namespace: [[ namespace ]]
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
   annotations:

--- a/operators/knative-controller/src/crds.yaml.j2
+++ b/operators/knative-controller/src/crds.yaml.j2
@@ -17,7 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -77,7 +77,7 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -781,7 +781,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -832,7 +832,7 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -1103,7 +1103,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -1164,7 +1164,7 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -1288,7 +1288,7 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -1449,7 +1449,7 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -2161,7 +2161,7 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -2336,7 +2336,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -2408,7 +2408,7 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
@@ -3177,7 +3177,7 @@ kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     knative.dev/crd-install: "true"
 spec:

--- a/operators/knative-controller/src/deployment.yaml.j2
+++ b/operators/knative-controller/src/deployment.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: [[ namespace ]]
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
 spec:
@@ -19,7 +19,7 @@ spec:
       labels:
         app: [[ name ]]
         app.kubernetes.io/component: controller
-        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/name: [[ name ]]
         app.kubernetes.io/version: "1.1.0"
         serving.knative.dev/release: "v1.1.0"
     spec:
@@ -83,7 +83,7 @@ metadata:
   labels:
     app: [[ name ]]
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
   name: [[ name ]]

--- a/operators/knative-controller/src/rbac.yaml.j2
+++ b/operators/knative-controller/src/rbac.yaml.j2
@@ -20,7 +20,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     serving.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -39,7 +39,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     serving.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -56,7 +56,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     serving.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
@@ -86,7 +86,7 @@ metadata:
     serving.knative.dev/controller: "true"
     serving.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services", "events", "serviceaccounts"]
@@ -142,7 +142,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
 # Do not use this role directly. These rules will be added to the "podspecable-binder" role.
@@ -166,7 +166,7 @@ metadata:
   namespace: [[ namespace ]]
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
 
@@ -177,7 +177,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
 aggregationRule:
@@ -193,7 +193,7 @@ metadata:
   name: knative-serving-controller-admin
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
 subjects:
@@ -213,7 +213,7 @@ metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     app.kubernetes.io/version: "1.1.0"
     serving.knative.dev/release: "v1.1.0"
 subjects:
@@ -237,7 +237,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -252,7 +252,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/name: [[ name ]]
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.

--- a/operators/knative-eventing-controller/src/charm.py
+++ b/operators/knative-eventing-controller/src/charm.py
@@ -37,7 +37,7 @@ class Operator(CharmBase):
             if err.status.code != 415:
                 raise
 
-        self.log.info(f"Got 415 response while applying {obj}, assuming ServerSideApply=false")
+        self.log.info(f"Got 415 response while applying {obj.kind}, assuming ServerSideApply=false")
 
         try:
             self.client.create(obj)
@@ -55,7 +55,7 @@ class Operator(CharmBase):
         )
 
         args = {"name": "eventing-controller", "namespace": self.model.name}
-        crds = Path("src/crds.yaml").read_text()
+        crds = env.get_template("crds.yaml").render(**args)
         rbac = env.get_template("rbac.yaml.j2").render(**args)
         deployment = env.get_template("deployment.yaml.j2").render(**args)
         config = env.get_template("config.yaml.j2").render(**args)

--- a/operators/knative-eventing-controller/src/config.yaml.j2
+++ b/operators/knative-eventing-controller/src/config.yaml.j2
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/eventing-name: [[ name ]]
 data:
   channelTemplateSpec: |
     apiVersion: messaging.knative.dev/v1
@@ -49,7 +49,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/eventing-name: [[ name ]]
 data:
   # Configures the default for any Broker that does not specify a spec.config or Broker class.
   default-br-config: |
@@ -83,7 +83,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/eventing-name: [[ name ]]
 data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-ch-config: |
@@ -118,11 +118,11 @@ metadata:
   labels:
     eventing.knative.dev/release: "v1.1.0"
   annotations:
-    knative.dev/example-checksum: "f8e5a744"
+    knative.dev/eventing-example-checksum: "f8e5a744"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/eventing-name: [[ name ]]
 data:
-  _example: |
+  _eventing_example: |
     ################################
     #                              #
     #    EXAMPLE CONFIGURATION     #
@@ -160,14 +160,14 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-features
+  name: eventing-config-features
   namespace: [[ namespace ]]
   labels:
     eventing.knative.dev/release: "v1.1.0"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/eventing-name: [[ name ]]
 data:
   # ALPHA feature: The kreference-group allows you to use the Group field in KReferences.
   # For more details: https://github.com/knative/eventing/issues/5086
@@ -214,9 +214,9 @@ metadata:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
   annotations:
-    knative.dev/example-checksum: "7375dbe1"
+    knative.dev/eventing-example-checksum: "7375dbe1"
 data:
-  _example: |
+  _eventing_example: |
     ################################
     #                              #
     #    EXAMPLE CONFIGURATION     #
@@ -261,11 +261,11 @@ metadata:
   labels:
     eventing.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/eventing-name: [[ name ]]
   annotations:
-    knative.dev/example-checksum: "96896b00"
+    knative.dev/eventing-example-checksum: "96896b00"
 data:
-  _example: |
+  _eventing_example: |
     ################################
     #                              #
     #    EXAMPLE CONFIGURATION     #
@@ -318,14 +318,14 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-logging
+  name: eventing-config-logging
   namespace: [[ namespace ]]
   labels:
     eventing.knative.dev/release: "v1.1.0"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/eventing-name: [[ name ]]
 data:
   # Common configuration for all Knative codebase
   zap-logger-config: |
@@ -372,18 +372,18 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-observability
+  name: eventing-config-observability
   namespace: [[ namespace ]]
   labels:
     eventing.knative.dev/release: "v1.1.0"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/eventing-name: [[ name ]]
   annotations:
-    knative.dev/example-checksum: "f46cf09d"
+    knative.dev/eventing-example-checksum: "f46cf09d"
 data:
-  _example: |
+  _eventing_example: |
     ################################
     #                              #
     #    EXAMPLE CONFIGURATION     #
@@ -449,18 +449,18 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-tracing
+  name: eventing-config-tracing
   namespace: [[ namespace ]]
   labels:
     eventing.knative.dev/release: "v1.1.0"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/eventing-name: [[ name ]]
   annotations:
-    knative.dev/example-checksum: "0492ceb0"
+    knative.dev/eventing-example-checksum: "0492ceb0"
 data:
-  _example: |
+  _eventing-example: |
     ################################
     #                              #
     #    EXAMPLE CONFIGURATION     #

--- a/operators/knative-eventing-controller/src/crds.yaml
+++ b/operators/knative-eventing-controller/src/crds.yaml
@@ -22,7 +22,7 @@ metadata:
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
   annotations:
     # TODO add schemas and descriptions
     registry.knative.dev/eventTypes: |
@@ -237,7 +237,7 @@ metadata:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   group: eventing.knative.dev
   versions:
@@ -405,7 +405,7 @@ metadata:
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   group: messaging.knative.dev
   versions:
@@ -677,7 +677,7 @@ metadata:
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
   name: containersources.sources.knative.dev
 spec:
   group: sources.knative.dev
@@ -829,7 +829,7 @@ metadata:
     eventing.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   group: eventing.knative.dev
   versions:
@@ -959,7 +959,7 @@ metadata:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   group: flows.knative.dev
   versions:
@@ -1215,7 +1215,7 @@ metadata:
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
   annotations:
     # TODO add schemas and descriptions
     registry.knative.dev/eventTypes: |
@@ -1405,7 +1405,7 @@ metadata:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   group: flows.knative.dev
   versions:
@@ -1727,7 +1727,7 @@ metadata:
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
   name: sinkbindings.sources.knative.dev
 spec:
   group: sources.knative.dev
@@ -1916,7 +1916,7 @@ metadata:
     eventing.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   group: messaging.knative.dev
   versions:
@@ -2128,7 +2128,7 @@ metadata:
     eventing.knative.dev/release: "v1.1.0"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   group: eventing.knative.dev
   versions:

--- a/operators/knative-eventing-controller/src/deployment.yaml.j2
+++ b/operators/knative-eventing-controller/src/deployment.yaml.j2
@@ -22,7 +22,7 @@ metadata:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: eventing-controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   selector:
     matchLabels:
@@ -34,7 +34,7 @@ spec:
         eventing.knative.dev/release: devel
         app.kubernetes.io/component: eventing-autoscaler
         app.kubernetes.io/version: devel
-        app.kubernetes.io/name: knative-eventing
+        app.kubernetes.io/name: [[ name ]]
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -65,9 +65,9 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: CONFIG_LOGGING_NAME
-            value: config-logging
+            value: eventing-config-logging
           - name: CONFIG_OBSERVABILITY_NAME
-            value: config-observability
+            value: eventing-config-observability
           - name: METRICS_DOMAIN
             value: knative.dev/eventing
           # APIServerSource

--- a/operators/knative-eventing-controller/src/rbac.yaml.j2
+++ b/operators/knative-eventing-controller/src/rbac.yaml.j2
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 rules:
   - apiGroups:
       - ""

--- a/operators/knative-eventing-webhook/src/deployment.yaml.j2
+++ b/operators/knative-eventing-webhook/src/deployment.yaml.j2
@@ -21,7 +21,7 @@ metadata:
     eventing.knative.dev/release: devel
     app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -47,7 +47,7 @@ metadata:
     eventing.knative.dev/release: devel
     app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   minAvailable: 80%
   selector:
@@ -77,7 +77,7 @@ metadata:
     eventing.knative.dev/release: devel
     app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 spec:
   selector:
     matchLabels: &labels
@@ -90,7 +90,7 @@ spec:
         eventing.knative.dev/release: devel
         app.kubernetes.io/component: eventing-webhook
         app.kubernetes.io/version: devel
-        app.kubernetes.io/name: knative-eventing
+        app.kubernetes.io/name: [[ name ]]
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -191,7 +191,7 @@ metadata:
     role: eventing-webhook
     app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
   name: [[ name ]]
   namespace: [[ namespace ]]
 spec:

--- a/operators/knative-eventing-webhook/src/secret.yaml
+++ b/operators/knative-eventing-webhook/src/secret.yaml
@@ -16,9 +16,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: eventing-webhook-certs
-  namespace: knative-eventing
+  namespace: [[ namespace ]]
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 # The data is populated at install time.

--- a/operators/knative-eventing-webhook/src/webhooks.yaml.j2
+++ b/operators/knative-eventing-webhook/src/webhooks.yaml.j2
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -98,7 +98,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -168,7 +168,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v1.1.0"
     app.kubernetes.io/version: "1.1.0"
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -251,5 +251,5 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/name: [[ name ]]
 # The data is populated at install time.


### PR DESCRIPTION
All manifest files in upstream KNative point to arbitrary namespaces and are configured with pre-defined names for annotations, namespaces, apps, etc. This commit changes the "hardcoded" values to something we can render to suit our needs.