### PR TITLE
fix: remove `series`, add `assumes` in metadata.yaml

### DIFF
--- a/operators/knative-activator/metadata.yaml
+++ b/operators/knative-activator/metadata.yaml
@@ -1,6 +1,5 @@
 name: knative-activator
 description: Kubernetes-based platform to deploy and manage modern serverless workloads.
-series: [kubernetes]
 summary: |
   Knative service - activator
 
@@ -8,3 +7,6 @@ summary: |
   Also retries requests to a revision after the autoscaler scales the revision based on the reported metrics.
 
   https://knative.dev/docs/serving/knative-kubernetes-services/#service-activator
+assumes:
+  - juju >= 2.9.23
+  - k8s-api

--- a/operators/knative-autoscaler/metadata.yaml
+++ b/operators/knative-autoscaler/metadata.yaml
@@ -1,9 +1,11 @@
 name: knative-autoscaler
 description: Kubernetes-based platform to deploy and manage modern serverless workloads.
-series: [kubernetes]
 summary: |
   Knative service - autoscaler
 
   Receives request metrics and adjusts the number of pods required to handle the load of traffic.
 
   https://knative.dev/docs/serving/knative-kubernetes-services/#service-autoscaler
+assumes:
+  - juju >= 2.9.23
+  - k8s-api

--- a/operators/knative-controller/metadata.yaml
+++ b/operators/knative-controller/metadata.yaml
@@ -1,6 +1,5 @@
 name: knative-controller
 description: Kubernetes-based platform to deploy and manage modern serverless workloads.
-series: [kubernetes]
 summary: |
   Knative service - controller
 
@@ -10,3 +9,6 @@ summary: |
   (KPAs).
 
   https://knative.dev/docs/serving/knative-kubernetes-services/#service-controller
+assumes:
+  - juju >= 2.9.23
+  - k8s-api

--- a/operators/knative-eventing-controller/metadata.yaml
+++ b/operators/knative-eventing-controller/metadata.yaml
@@ -1,5 +1,7 @@
 name: knative-eventing-controller
 description: Kubernetes-based platform to deploy and manage modern serverless workloads.
-series: [kubernetes]
 summary: |
   Knative eventing controller
+assumes:
+  - juju >= 2.9.23
+  - k8s-api

--- a/operators/knative-eventing-webhook/metadata.yaml
+++ b/operators/knative-eventing-webhook/metadata.yaml
@@ -1,5 +1,7 @@
 name: knative-eventing-webhook
 description: Kubernetes-based platform to deploy and manage modern serverless workloads.
-series: [kubernetes]
 summary: |
   Knative eventing webhook
+assumes:
+  - juju >= 2.9.23
+  - k8s-api

--- a/operators/knative-istio-controller/metadata.yaml
+++ b/operators/knative-istio-controller/metadata.yaml
@@ -1,5 +1,7 @@
 name: knative-istio-controller
 description: Kubernetes-based platform to deploy and manage modern serverless workloads.
-series: [kubernetes]
 summary: |
   Knative service - istio-controller
+assumes:
+  - juju >= 2.9.23
+  - k8s-api

--- a/operators/knative-webhook/metadata.yaml
+++ b/operators/knative-webhook/metadata.yaml
@@ -1,6 +1,5 @@
 name: knative-webhook
 description: Kubernetes-based platform to deploy and manage modern serverless workloads.
-series: [kubernetes]
 summary: |
   Knative service - activator
 
@@ -8,3 +7,6 @@ summary: |
   values, rejects inconsitent and invalid objects, and validates and mutates Kubernetes API calls.
 
   https://knative.dev/docs/serving/knative-kubernetes-services/#service-webhook
+assumes:
+  - juju >= 2.9.23
+  - k8s-api


### PR DESCRIPTION
Including `series` makes `--trust` not work on deployments.  I THINK including `series: [kubernetes]` made the charm actually deploy as podspec and not as sidecar, which then makes it behave very differently.  Not sure though.