### PR TITLE
fix: deduplicate integration ci

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
Fixes issue where, on pushes to open pull requests, the integration CI runs twice (once for push (to the PR), and once for the PR update itself)