### PR TITLE
knative-eventing: adapts supporting files to knative-eventing needs

### DIFF
--- a/charms/knative-eventing/charmcraft.yaml
+++ b/charms/knative-eventing/charmcraft.yaml
@@ -9,3 +9,7 @@ bases:
     run-on:
       - name: "ubuntu"
         channel: "20.04"
+parts:
+  charm:
+    charm-python-packages: [setuptools, pip]
+    build-packages: [git]

--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -1,14 +1,8 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-#
-# TEMPLATE-TODO: change this example to suit your needs.
-# If you don't need a config, you can remove the file entirely.
-# It ties in to the example _on_config_changed handler in src/charm.py
-#
-# Learn more about config at: https://juju.is/docs/sdk/config
 
 options:
-  thing:
-    default: 🎁
-    description: A thing used by the charm.
+  namespace:
+    default: ""
+    description: The namespace to deploy Eventing to. This namespace cannot also contain another Knative Serving or Eventing instance. This configuration is required.
     type: string

--- a/charms/knative-eventing/metadata.yaml
+++ b/charms/knative-eventing/metadata.yaml
@@ -1,23 +1,12 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# For a complete list of supported options, see:
-# https://juju.is/docs/sdk/metadata-reference
 name: knative-eventing
 description: |
-  TEMPLATE-TODO: fill out the charm's description
+  Knative Eventing provides tools for routing events from event producers to sinks,
+  enabling developers to use an event-driven architecture with their applications.
+  This charm presents a simplified interface for deploying Knative Eventing in Juju,
+  handling the creation of Kubernetes objects required to request a Knative Eventing
+  application from the a Knative Operator.
 summary: |
-  TEMPLATE-TODO: fill out the charm's summary
-
-# TEMPLATE-TODO: replace with containers for your workload (delete for non-k8s)
-containers:
-  httpbin:
-    resource: httpbin-image
-
-# TEMPLATE-TODO: each container defined above must specify an oci-image resource
-resources:
-  httpbin-image:
-    type: oci-image
-    description: OCI image for httpbin (kennethreitz/httpbin)
-    # Included for simplicity in integration tests
-    upstream-source: kennethreitz/httpbin
+  Knative Eventing deployment for Charmed Operators in Kubernetes 

--- a/charms/knative-eventing/requirements.txt
+++ b/charms/knative-eventing/requirements.txt
@@ -1,1 +1,2 @@
 ops >= 1.2.0
+git+https://github.com/canonical/k8s-resource-handler.git@ca-scribner/refactor-kubernetes-resource-handler-api

--- a/charms/knative-eventing/tox.ini
+++ b/charms/knative-eventing/tox.ini
@@ -58,6 +58,7 @@ commands =
 description = Run unit tests
 deps =
     pytest
+    pytest-mock
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Makes changes on supporting files, adding configuration, metadata, requirements and other generics needed to build and operate.
This is built on top of #15 