### PR TITLE
knative-serving: adapts supporting files to knative-serving needs

### DIFF
--- a/charms/knative-serving/charmcraft.yaml
+++ b/charms/knative-serving/charmcraft.yaml
@@ -9,3 +9,7 @@ bases:
     run-on:
       - name: "ubuntu"
         channel: "20.04"
+parts:
+  charm:
+    charm-python-packages: [setuptools, pip]
+    build-packages: [git]

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -1,14 +1,24 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-#
-# TEMPLATE-TODO: change this example to suit your needs.
-# If you don't need a config, you can remove the file entirely.
-# It ties in to the example _on_config_changed handler in src/charm.py
-#
-# Learn more about config at: https://juju.is/docs/sdk/config
 
 options:
-  thing:
-    default: 🎁
-    description: A thing used by the charm.
+  version:
+    default: "1.1.0"
+    description: Version of knative-serving component. If not set, it defaults to 1.1.0. If configured, this version has to be >1.1.0
+    type: string
+  namespace:
+    default: ""
+    description: The namespace to deploy Eventing to. This namespace cannot also contain another Knative Serving or Eventing instance. This configuration is required.
+    type: string
+  domain.name:
+    default: "10.64.140.43.nip.io"
+    description: The domain name used for all fully-qualified route names shown
+    type: string
+  istio.gateway.name:
+    default: "knative-gateway"
+    description: (TEMP) The name of the Istio Gateway to use for Knative Serving
+    type: string
+  istio.gateway.namespace:
+    default: ""
+    description: (TEMP) The namespace where istio is deployed. It is usually the model name where istio (pilot and gateway) are deployed. This configuration is required.
     type: string

--- a/charms/knative-serving/metadata.yaml
+++ b/charms/knative-serving/metadata.yaml
@@ -1,23 +1,12 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# For a complete list of supported options, see:
-# https://juju.is/docs/sdk/metadata-reference
 name: knative-serving
 description: |
-  TEMPLATE-TODO: fill out the charm's description
+  Knative Serving provides components that enable rapid deployment of serverless
+  containers, support for multiple networking layers, autoscaling (even to zero),
+  and revision tracking. This charm presents a simplified interface for deploying
+  Knative Serving in Juju, handling the creation of Kubernetes objects required to
+  request a Knative Serving application from the a Knative Operator.
 summary: |
-  TEMPLATE-TODO: fill out the charm's summary
-
-# TEMPLATE-TODO: replace with containers for your workload (delete for non-k8s)
-containers:
-  httpbin:
-    resource: httpbin-image
-
-# TEMPLATE-TODO: each container defined above must specify an oci-image resource
-resources:
-  httpbin-image:
-    type: oci-image
-    description: OCI image for httpbin (kennethreitz/httpbin)
-    # Included for simplicity in integration tests
-    upstream-source: kennethreitz/httpbin
+  Knative Serving deployment for Charmed Operators in Kubernetes

--- a/charms/knative-serving/requirements.txt
+++ b/charms/knative-serving/requirements.txt
@@ -1,1 +1,2 @@
 ops >= 1.2.0
+git+https://github.com/canonical/k8s-resource-handler.git@ca-scribner/refactor-kubernetes-resource-handler-api

--- a/charms/knative-serving/tox.ini
+++ b/charms/knative-serving/tox.ini
@@ -58,6 +58,7 @@ commands =
 description = Run unit tests
 deps =
     pytest
+    pytest-mock
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Makes changes on supporting files, adding configuration, metadata, requirements and other generics needed to build and operate.
This is built on top of #16 