### PR TITLE
 knative-serving: initial implementation of the charm 

### DIFF
--- a/charms/knative-serving/requirements.txt
+++ b/charms/knative-serving/requirements.txt
@@ -1,2 +1,2 @@
 ops >= 1.2.0
-git+https://github.com/canonical/k8s-resource-handler.git@ca-scribner/refactor-kubernetes-resource-handler-api
+charmed-kubeflow-chisme

--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -4,101 +4,90 @@
 #
 # Learn more at: https://juju.is/docs/sdk
 
-"""Charm the service.
+"""A Juju charm for Knative Serving."""
 
-Refer to the following post for a quick-start guide that will help you
-develop a new k8s charm using the Operator Framework:
-
-    https://discourse.charmhub.io/t/4208
-"""
-
+import glob
 import logging
+import traceback
+from pathlib import Path
 
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from charmed_kubeflow_chisme.kubernetes import (  # noqa N813
+    KubernetesResourceHandler as KRH,
+)
+from lightkube.core.exceptions import ApiError
 from ops.charm import CharmBase
-from ops.framework import StoredState
 from ops.main import main
-from ops.model import ActiveStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+
+from lightkube_custom_resources.operator import KnativeServing_v1alpha1  # noqa F401
 
 logger = logging.getLogger(__name__)
 
 
-class OperatorTemplateCharm(CharmBase):
-    """Charm the service."""
-
-    _stored = StoredState()
+class KnativeServingCharm(CharmBase):
+    """A charm for creating Knative Serving instances via the Knative Operator."""
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.framework.observe(self.on.httpbin_pebble_ready, self._on_httpbin_pebble_ready)
+
+        self._app_name = self.app.name
+        self._namespace = self.model.name
+
+        self.resource_handler = KRH(
+            template_files=self._template_files,
+            context=self._context,
+            field_manager="lightkube",
+        )
+        self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
-        self.framework.observe(self.on.fortune_action, self._on_fortune_action)
-        self._stored.set_default(things=[])
 
-    def _on_httpbin_pebble_ready(self, event):
-        """Define and start a workload using the Pebble API.
+    def _apply_and_set_status(self):
+        try:
+            self.unit.status = MaintenanceStatus("Configuring/deploying resources")
+            self.resource_handler.apply()
+        except (ApiError, ErrorWithStatus) as e:
+            logger.debug(traceback.format_exc())
+            if isinstance(e, ApiError):
+                logger.info(f"Applying resources failed with ApiError status code {e.status.code}")
+                self.unit.status = BlockedStatus(f"ApiError: {e.status.code}")
+            else:
+                logger.info(e.msg)
+                self.unit.status = e.status
+        else:
+            # TODO: once the resource handler v0.0.2 is out,
+            # let's use the compute_status() method to set (or not)
+            # an active status
+            self.unit.status = ActiveStatus()
 
-        TEMPLATE-TODO: change this example to suit your needs.
-        You'll need to specify the right entrypoint and environment
-        configuration for your specific workload. Tip: you can see the
-        standard entrypoint of an existing container using docker inspect
-
-        Learn more about Pebble layers at https://github.com/canonical/pebble
-        """
-        # Get a reference the container attribute on the PebbleReadyEvent
-        container = event.workload
-        # Define an initial Pebble layer configuration
-        pebble_layer = {
-            "summary": "httpbin layer",
-            "description": "pebble config layer for httpbin",
-            "services": {
-                "httpbin": {
-                    "override": "replace",
-                    "summary": "httpbin",
-                    "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
-                    "startup": "enabled",
-                    "environment": {"thing": self.model.config["thing"]},
-                }
-            },
-        }
-        # Add initial Pebble config layer using the Pebble API
-        container.add_layer("httpbin", pebble_layer, combine=True)
-        # Autostart any services that were defined with startup: enabled
-        container.autostart()
-        # Learn more about statuses in the SDK docs:
-        # https://juju.is/docs/sdk/constructs#heading--statuses
-        self.unit.status = ActiveStatus()
+    def _on_install(self, _):
+        if not self.model.config["namespace"]:
+            self.model.unit.status = BlockedStatus("Config item `namespace` must be set")
+            return
+        self._apply_and_set_status()
 
     def _on_config_changed(self, _):
-        """Just an example to show how to deal with changed configuration.
+        self._apply_and_set_status()
 
-        TEMPLATE-TODO: change this example to suit your needs.
-        If you don't need to handle config, you can remove this method,
-        the hook created in __init__.py for it, the corresponding test,
-        and the config.py file.
+    @property
+    def _template_files(self):
+        src_dir = Path("src")
+        manifests_dir = src_dir / "manifests"
+        eventing_manifests = [file for file in glob.glob(f"{manifests_dir}/*.yaml.j2")]
+        return eventing_manifests
 
-        Learn more about config at https://juju.is/docs/sdk/config
-        """
-        current = self.config["thing"]
-        if current not in self._stored.things:
-            logger.debug("found a new thing: %r", current)
-            self._stored.things.append(current)
-
-    def _on_fortune_action(self, event):
-        """Just an example to show how to receive actions.
-
-        TEMPLATE-TODO: change this example to suit your needs.
-        If you don't need to handle actions, you can remove this method,
-        the hook created in __init__.py for it, the corresponding test,
-        and the actions.py file.
-
-        Learn more about actions at https://juju.is/docs/sdk/actions
-        """
-        fail = event.params["fail"]
-        if fail:
-            event.fail(fail)
-        else:
-            event.set_results({"fortune": "A bug in the code is worth two in the documentation."})
+    @property
+    def _context(self):
+        context = {
+            "app_name": self._app_name,
+            "domain": self.model.config["domain.name"],
+            "gateway_name": self.model.config["istio.gateway.name"],
+            "gateway_namespace": self.model.config["istio.gateway.namespace"],
+            "serving_namespace": self.model.config["namespace"],
+            "serving_version": self.model.config["version"],
+        }
+        return context
 
 
 if __name__ == "__main__":
-    main(OperatorTemplateCharm)
+    main(KnativeServingCharm)

--- a/charms/knative-serving/src/lightkube_custom_resources/operator.py
+++ b/charms/knative-serving/src/lightkube_custom_resources/operator.py
@@ -1,0 +1,32 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Knative Serving custom resource classes."""
+
+from lightkube.generic_resource import create_namespaced_resource
+
+# Knative Operator's KnativeServing CRDs
+KnativeServing_v1alpha1 = create_namespaced_resource(
+    group="operator.knative.dev",
+    version="v1alpha1",
+    kind="KnativeServing",
+    plural="knativeservings",
+    verbs=None,
+)
+# v1.3 and above
+KnativeServing_v1beta1 = create_namespaced_resource(
+    group="operator.knative.dev",
+    version="v1beta1",
+    kind="KnativeServing",
+    plural="knativeservings",
+    verbs=None,
+)
+
+# Knative Operator's KnativeEventing CRDs
+KnativeEventing_v1beta1 = create_namespaced_resource(
+    group="operator.knative.dev",
+    version="v1beta1",
+    kind="KnativeEventing",
+    plural="knativeeventings",
+    verbs=None,
+)

--- a/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
+++ b/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
@@ -1,0 +1,23 @@
+# beta1 is for knative operator v1.3
+# apiVersion: operator.knative.dev/v1beta1
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: {{ app_name }}
+  # TODO: make this configurable
+  namespace: {{ namespace }}
+spec:
+  version: {{ serving_version }}
+  config:
+    # This is analogous to the config-istio configmap
+    istio:
+      # TODO
+      # To define the external gateway:
+      # gateway.NAMESPACE-OF-GATEWAY.NAME-OF-GATEWAY: SOME-SERVICE.SOME-NAMESPACE.svc.cluste.local (I dont know what this is for, but if we cite an invalid namespace here the knative-serving object will not fully deploy)
+      gateway.{{ gateway_namespace }}.{{ gateway_name }}: "some-workload.knative-operator.svc.cluster.local"
+      # Defines the internal (inside cluster) gateway (which, if we don't enforce istio rules, I think doesn't matter so much?):
+      # local-gateway.NAMESPACE-OF-GATEWAY.NAME-OF-GATEWAY: SOME-SERVICE.SOME-NAMESPACE.svc.cluste.local (I dont know what this is for, but if we cite an invalid namespace here the knative-serving object will not fully deploy)
+      local-gateway.knative-serving.knative-local-gateway: "some-workload.knative-operator.svc.cluster.local"
+    # This is analogous to the config-domain configmap
+    domain:
+      {{ domain }}: ""

--- a/charms/knative-serving/src/manifests/Namespace.yaml.j2
+++ b/charms/knative-serving/src/manifests/Namespace.yaml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ serving_namespace }}

--- a/charms/knative-serving/tests/unit/conftest.py
+++ b/charms/knative-serving/tests/unit/conftest.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest import mock
+
+import pytest
+from ops.testing import Harness
+
+from charm import KnativeServingCharm
+
+
+@pytest.fixture()
+def mocked_lightkube_client_class(mocker):
+    """Prevents lightkube clients from being created, returning a mock instead."""
+    mocked_lightkube_client_class = mocker.patch(
+        "charmed_kubeflow_chisme.kubernetes._kubernetes_resource_handler.Client"
+    )
+    mocked_lightkube_client_class.return_value = mock.MagicMock()
+    yield mocked_lightkube_client_class
+
+
+@pytest.fixture()
+def mocked_lightkube_client(mocked_lightkube_client_class):
+    """Prevents lightkube clients from being created, returning a mock instead."""
+    yield mocked_lightkube_client_class()
+
+
+@pytest.fixture
+def harness():
+    """Returns a harnessed charm with leader == True."""
+    harness = Harness(KnativeServingCharm)
+    harness.set_leader(True)
+    return harness

--- a/charms/knative-serving/tests/unit/test_charm.py
+++ b/charms/knative-serving/tests/unit/test_charm.py
@@ -1,67 +1,56 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-#
-# Learn more about testing at: https://juju.is/docs/sdk/testing
+from unittest.mock import MagicMock
 
-import unittest
-from unittest.mock import Mock
-
-from ops.model import ActiveStatus
-from ops.testing import Harness
-
-from charm import OperatorTemplateCharm
+import pytest
+from charmed_kubeflow_chisme.lightkube.mocking import FakeApiError
+from ops.model import ActiveStatus, BlockedStatus
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        self.harness = Harness(OperatorTemplateCharm)
-        self.addCleanup(self.harness.cleanup)
-        self.harness.begin()
+def test_events(harness, mocked_lightkube_client):
+    # Test install and config_changed event handlers are called
+    harness.begin()
+    harness.charm._on_install = MagicMock()
+    harness.charm._on_config_changed = MagicMock()
 
-    def test_config_changed(self):
-        self.assertEqual(list(self.harness.charm._stored.things), [])
-        self.harness.update_config({"thing": "foo"})
-        self.assertEqual(list(self.harness.charm._stored.things), ["foo"])
+    harness.charm.on.install.emit()
+    harness.charm._on_install.assert_called_once()
 
-    def test_action(self):
-        # the harness doesn't (yet!) help much with actions themselves
-        action_event = Mock(params={"fail": ""})
-        self.harness.charm._on_fortune_action(action_event)
+    harness.charm.on.config_changed.emit()
+    harness.charm._on_config_changed.assert_called_once()
 
-        self.assertTrue(action_event.set_results.called)
 
-    def test_action_fail(self):
-        action_event = Mock(params={"fail": "fail this"})
-        self.harness.charm._on_fortune_action(action_event)
+def test_on_install_active(harness, mocked_lightkube_client):
+    harness.begin()
+    harness.update_config({"namespace": "test"})
+    harness.charm.resource_handler.apply = MagicMock()
+    harness.charm.resource_handler.apply.return_value = None
+    harness.charm.on.install.emit()
+    assert harness.model.unit.status == ActiveStatus()
 
-        self.assertEqual(action_event.fail.call_args, [("fail this",)])
 
-    def test_httpbin_pebble_ready(self):
-        # Check the initial Pebble plan is empty
-        initial_plan = self.harness.get_container_pebble_plan("httpbin")
-        self.assertEqual(initial_plan.to_yaml(), "{}\n")
-        # Expected plan after Pebble ready with default config
-        expected_plan = {
-            "services": {
-                "httpbin": {
-                    "override": "replace",
-                    "summary": "httpbin",
-                    "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
-                    "startup": "enabled",
-                    "environment": {"thing": "🎁"},
-                }
-            },
-        }
-        # Get the httpbin container from the model
-        container = self.harness.model.unit.get_container("httpbin")
-        # Emit the PebbleReadyEvent carrying the httpbin container
-        self.harness.charm.on.httpbin_pebble_ready.emit(container)
-        # Get the plan now we've run PebbleReady
-        updated_plan = self.harness.get_container_pebble_plan("httpbin").to_dict()
-        # Check we've got the plan we expected
-        self.assertEqual(expected_plan, updated_plan)
-        # Check the service was started
-        service = self.harness.model.unit.get_container("httpbin").get_service("httpbin")
-        self.assertTrue(service.is_running())
-        # Ensure we set an ActiveStatus with no message
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+@pytest.mark.parametrize(
+    "apply_error, raised_exception",
+    (
+        (FakeApiError(400), pytest.raises(FakeApiError)),
+        (
+            FakeApiError(403),
+            pytest.raises(FakeApiError),
+        ),
+    ),
+)
+def test_apply_and_set_status_blocked(
+    apply_error,
+    raised_exception,
+    harness,
+    mocked_lightkube_client,
+    mocker,
+):
+    harness.begin()
+    harness.charm.resource_handler.apply = MagicMock()
+    harness.charm.resource_handler.apply.side_effect = apply_error
+
+    harness.charm._apply_and_set_status()
+    with raised_exception:
+        harness.charm.resource_handler.apply()
+    assert isinstance(harness.model.unit.status, BlockedStatus)


### PR DESCRIPTION
Initial implementation of knative-eventing, this PR includes changes in the charm code for handling Install and ConfigChanged events using [`charmed-kubeflow-chisme`](https://github.com/canonical/charmed-kubeflow-chisme). This PR also introduces unit tests for the charm.

This is built on top of #18 