### PR TITLE
Adds integration test cases for running serving-eventing example

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -58,6 +58,7 @@ jobs:
           provider: microk8s
           channel: 1.21/stable
 
+      - run: sg microk8s -c "microk8s enable metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"
       - run: juju add-model knative-test
 
       - name: Run integration tests

--- a/examples/cloudevents-player.yaml
+++ b/examples/cloudevents-player.yaml
@@ -1,0 +1,15 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: cloudevents-player
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "1"
+    spec:
+      containers:
+        - image: ruromero/cloudevents-player:latest
+          env:
+            - name: BROKER_URL
+              value: http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
+# Remove once python-libjuju>2.9.10 is released
+git+https://github.com/juju/python-libjuju@master
 pytest-operator<1.0
 asyncio<3.5
 PyYAML==6.0

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,9 +1,11 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import logging
 
 import pytest
+import requests
 import yaml
 from pytest_operator.plugin import OpsTest
 
@@ -41,14 +43,35 @@ async def test_kubectl_access(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_build_deploy_knative_charms(ops_test: OpsTest):
+    # Deploy istio as dependency
+    await ops_test.model.deploy(
+        "istio-pilot",
+        channel="latest/edge",
+        config={"default-gateway": "knative-gateway"},
+        trust=True,
+    )
+    await ops_test.model.deploy(
+        "istio-gateway",
+        application_name="istio-ingressgateway",
+        channel="latest/edge",
+        config={"kind": "ingress"},
+        trust=True,
+    )
+    await ops_test.model.add_relation("istio-pilot", "istio-ingressgateway")
+
+    await ops_test.model.wait_for_idle(
+        ["istio-pilot", "istio-ingressgateway"],
+        raise_on_blocked=False,
+        status="active",
+        timeout=90 * 10,
+    )
+
     # Build and deploy knative charms
     charms_path = "./charms/knative"
     knative_charms = await ops_test.build_charms(
         f"{charms_path}-operator", f"{charms_path}-serving", f"{charms_path}-eventing"
     )
 
-    # TODO: Remove httpbin-image argument from `resource` parameter
-    # once we populate charms/knative-* with knative specific code
     knative_operator_image = "gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.1.0"
     await ops_test.model.deploy(
         knative_charms["knative-operator"],
@@ -57,28 +80,75 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest):
         resources={"knative-operator-image": knative_operator_image},
     )
 
+    await ops_test.model.wait_for_idle(
+        ["knative-operator"],
+        status="active",
+        raise_on_blocked=False,
+        timeout=90 * 10,
+    )
+
     await ops_test.model.deploy(
         knative_charms["knative-serving"],
         application_name="knative-serving",
+        config={"namespace": "knative-serving", "istio.gateway.namespace": ops_test.model_name},
         trust=True,
-        resources={"httpbin-image": "kennethreitz/httpbin"},
     )
 
     await ops_test.model.deploy(
         knative_charms["knative-eventing"],
         application_name="knative-eventing",
+        config={"namespace": "knative-eventing"},
         trust=True,
-        resources={"httpbin-image": "kennethreitz/httpbin"},
     )
 
     await ops_test.model.wait_for_idle(
+        ["knative-serving", "knative-eventing"],
         status="active",
         raise_on_blocked=False,
         timeout=90 * 10,
     )
 
 
-@pytest.mark.abort_on_fail
-async def test_example(ops_test: OpsTest):
-    # This is a placeholder test case
-    pass
+async def test_cloud_events_player_example(ops_test: OpsTest):
+    await ops_test.run(
+        "kubectl",
+        "apply",
+        "-f",
+        "./examples/cloudevents-player.yaml",
+        check=True,
+    )
+    await ops_test.run(
+        "kubectl",
+        "wait",
+        "--for=condition=ready",
+        "ksvc",
+        "cloudevents-player",
+        "--timeout=5m",
+        check=True,
+    )
+
+    gateway_json = await ops_test.run(
+        "kubectl",
+        "get",
+        "services/istio-ingressgateway-workload",
+        "-n",
+        ops_test.model_name,
+        "-ojson",
+        check=True,
+    )
+
+    gateway_obj = json.loads(gateway_json[1])
+    gateway_ip = gateway_obj["status"]["loadBalancer"]["ingress"][0]["ip"]
+    url = f"http://cloudevents-player.default.{gateway_ip}.nip.io/messages"
+    data = {"msg": "Hello CloudEvents!"}
+    headers = {
+        "Content-Type": "application/json",
+        "Ce-Id": "123456789",
+        "Ce-Specversion": "1.0",
+        "Ce-Type": "some-type",
+        "Ce-Source": "command-line",
+    }
+    post_req = requests.post(url, data=data, headers=headers, allow_redirects=False, verify=False)
+    assert post_req.status_code == 202
+    get_req = requests.get(url, allow_redirects=False, verify=False)
+    assert get_req.status_code == 202

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -43,6 +43,12 @@ async def test_kubectl_access(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_build_deploy_knative_charms(ops_test: OpsTest):
+    # Build knative charms
+    charms_path = "./charms/knative"
+    knative_charms = await ops_test.build_charms(
+        f"{charms_path}-operator", f"{charms_path}-serving", f"{charms_path}-eventing"
+    )
+
     # Deploy istio as dependency
     await ops_test.model.deploy(
         "istio-pilot",
@@ -50,6 +56,7 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest):
         config={"default-gateway": "knative-gateway"},
         trust=True,
     )
+
     await ops_test.model.deploy(
         "istio-gateway",
         application_name="istio-ingressgateway",
@@ -57,6 +64,7 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest):
         config={"kind": "ingress"},
         trust=True,
     )
+
     await ops_test.model.add_relation("istio-pilot", "istio-ingressgateway")
 
     await ops_test.model.wait_for_idle(
@@ -66,12 +74,7 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest):
         timeout=90 * 10,
     )
 
-    # Build and deploy knative charms
-    charms_path = "./charms/knative"
-    knative_charms = await ops_test.build_charms(
-        f"{charms_path}-operator", f"{charms_path}-serving", f"{charms_path}-eventing"
-    )
-
+    # Deploy knative charms
     knative_operator_image = "gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.1.0"
     await ops_test.model.deploy(
         knative_charms["knative-operator"],

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -139,7 +139,7 @@ async def test_cloud_events_player_example(ops_test: OpsTest):
 
     gateway_obj = json.loads(gateway_json[1])
     gateway_ip = gateway_obj["status"]["loadBalancer"]["ingress"][0]["ip"]
-    url = f"http://cloudevents-player.default.{gateway_ip}.nip.io/messages"
+    url = f"http://cloudevents-player.default.{gateway_ip}.nip.io"
     data = {"msg": "Hello CloudEvents!"}
     headers = {
         "Content-Type": "application/json",
@@ -150,5 +150,5 @@ async def test_cloud_events_player_example(ops_test: OpsTest):
     }
     post_req = requests.post(url, data=data, headers=headers, allow_redirects=False, verify=False)
     assert post_req.status_code == 202
-    get_req = requests.get(url, allow_redirects=False, verify=False)
+    get_req = requests.get(f"{url}/messages", allow_redirects=False, verify=False)
     assert get_req.status_code == 202

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -148,7 +148,7 @@ async def test_cloud_events_player_example(ops_test: OpsTest):
         "Ce-Type": "some-type",
         "Ce-Source": "command-line",
     }
-    post_req = requests.post(url, data=data, headers=headers, allow_redirects=False, verify=False)
+    post_req = requests.post(url, json=data, headers=headers, allow_redirects=False, verify=False)
     assert post_req.status_code == 202
     get_req = requests.get(f"{url}/messages", allow_redirects=False, verify=False)
-    assert get_req.status_code == 202
+    assert get_req.status_code == 200


### PR DESCRIPTION
Adds integration test case that deploys istio-operators and knative-operators, then runs a knative-serving and eventing [example](https://knative.dev/docs/getting-started/first-source/). 
This PR also introduces changes to the integration Github workflow to enable metallb in the testing environment.

Merge after #36 and #37 