### PR TITLE
knative-serving: small fixes and chores

### DIFF
--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -49,10 +49,12 @@ class KnativeServingCharm(CharmBase):
         except (ApiError, ErrorWithStatus) as e:
             logger.debug(traceback.format_exc())
             if isinstance(e, ApiError):
-                logger.info(f"Applying resources failed with ApiError status code {e.status.code}")
+                logger.error(
+                    f"Applying resources failed with ApiError status code {e.status.code}"
+                )
                 self.unit.status = BlockedStatus(f"ApiError: {e.status.code}")
             else:
-                logger.info(e.msg)
+                logger.error(e.msg)
                 self.unit.status = e.status
         else:
             # TODO: once the resource handler v0.0.2 is out,

--- a/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
+++ b/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
@@ -5,7 +5,7 @@ kind: KnativeServing
 metadata:
   name: {{ app_name }}
   # TODO: make this configurable
-  namespace: {{ namespace }}
+  namespace: {{ serving_namespace }}
 spec:
   version: {{ serving_version }}
   config:


### PR DESCRIPTION
This PR changes how errors are logged replacing `logger.info` with `logger.error`. It also corrects a variable name in the KnativeServing manifest.