### PR TITLE
knative-operator: creates knative-operator namespace

### DIFF
--- a/charms/knative-operator/src/charm.py
+++ b/charms/knative-operator/src/charm.py
@@ -33,6 +33,7 @@ class KnativeOperatorCharm(CharmBase):
             "service_account.yaml",
             "crds_manifests.yaml",
             "istio_ns.yaml",
+            "operator_ns.yaml",
             # Skipping config manifests for now
             # "config_manifests.yaml",
         )

--- a/charms/knative-operator/src/operator_ns.yaml
+++ b/charms/knative-operator/src/operator_ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-operator


### PR DESCRIPTION
The knative-operator namespace is required by the knative-serving
controller. It seems like this is a hardcoded value in the upstream
code and thus, this is a needed workaround.

Fixes #30