### PR TITLE
ci: removes destructive mode from tox command options

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run integration tests
 
-        run: tox -vve integration -- --model knative-test --destructive-mode
+        run: tox -vve integration -- --model knative-test
         env:
           KUBECONFIG: /home/runner/.kube/config
 


### PR DESCRIPTION
Do not merge. This is a test.