### PR TITLE
fix: correct local-gateway configuration for knative-serving

### DIFF
--- a/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
+++ b/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
@@ -15,9 +15,11 @@ spec:
       # To define the external gateway:
       # gateway.NAMESPACE-OF-GATEWAY.NAME-OF-GATEWAY: SOME-SERVICE.SOME-NAMESPACE.svc.cluste.local (I dont know what this is for, but if we cite an invalid namespace here the knative-serving object will not fully deploy)
       gateway.{{ gateway_namespace }}.{{ gateway_name }}: "some-workload.knative-operator.svc.cluster.local"
-      # Defines the internal (inside cluster) gateway (which, if we don't enforce istio rules, I think doesn't matter so much?):
-      # local-gateway.NAMESPACE-OF-GATEWAY.NAME-OF-GATEWAY: SOME-SERVICE.SOME-NAMESPACE.svc.cluste.local (I dont know what this is for, but if we cite an invalid namespace here the knative-serving object will not fully deploy)
-      local-gateway.knative-serving.knative-local-gateway: "some-workload.knative-operator.svc.cluster.local"
+      # Defines the internal (inside cluster) gateway:
+      # local-gateway.<local-gateway-namespace>.knative-local-gateway: "knative-local-gateway.<istio-namespace>.svc.cluster.local"
+      # Where local-gateway-namespace is the same as the knative-namespace and istio-namespace is where istio is deployed, in this particular
+      # case we know the gateway namespace and the istio namespace will be the same
+      local-gateway.{{ serving_namespace }}.knative-local-gateway: "knative-local-gateway.{{ gateway_namespace }}.svc.cluster.local"
     # This is analogous to the config-domain configmap
     domain:
       {{ domain }}: ""


### PR DESCRIPTION
The configuration of the local gateway was missing important keys,
like the gateway/istio namespace and the serving namespace. This
commit changes the configuration to avoid issues when sending/receiving
CloudEvents from different sources.

Fixes: canonical/knative-operators#40

Merge after #42 