### PR TITLE
ci: pin flake8 to version 4.0.1 to avoid breaking changes with versions >= 5.x.x

### DIFF
--- a/charms/knative-eventing/tox.ini
+++ b/charms/knative-eventing/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/charms/knative-operator/tox.ini
+++ b/charms/knative-operator/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/charms/knative-serving/tox.ini
+++ b/charms/knative-serving/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ git+https://github.com/juju/python-libjuju@master
 pytest-operator<1.0
 asyncio<3.5
 PyYAML==6.0
+flake8==4.0.1


### PR DESCRIPTION
To avoid [errors](https://github.com/canonical/knative-operators/runs/7683678548?check_suite_focus=true#step:4:25) with breaking changes between v4.x and v5.x