### PR TITLE
use chisme update_layer

### DIFF
--- a/charms/knative-operator/requirements.txt
+++ b/charms/knative-operator/requirements.txt
@@ -1,4 +1,5 @@
 charmed-kubeflow-chisme
 jinja2<3.1
 ops<1.4.0
-lightkube>=0.10.1
+lightkube==0.11.0
+charmed-kubeflow-chisme

--- a/charms/knative-operator/src/charm.py
+++ b/charms/knative-operator/src/charm.py
@@ -119,7 +119,7 @@ class KnativeOperatorCharm(CharmBase):
                 logger.error(str(e.msg))
             else:
                 logger.info(str(e.msg))
-            event.defer()
+                event.defer()
 
         # Apply Kubernetes resources
         self.unit.status = MaintenanceStatus("Applying resources")
@@ -136,7 +136,7 @@ class KnativeOperatorCharm(CharmBase):
                 logger.error(str(e.msg))
             else:
                 logger.info(str(e.msg))
-            event.defer()
+                event.defer()
 
         self.unit.status = ActiveStatus()
 

--- a/charms/knative-operator/tests/unit/test_charm.py
+++ b/charms/knative-operator/tests/unit/test_charm.py
@@ -2,30 +2,14 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
 from lightkube.core.exceptions import ApiError
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
-from ops.pebble import Change, ChangeError, ChangeID
 from ops.testing import Harness
 
 from charm import KnativeOperatorCharm
-
-
-class _FakeChange:
-    def __init__(self):
-        self.cid = ChangeID("0")
-        self.spawn_time = datetime.datetime.now()
-        self.change = Change(
-            self.cid, "kind", "summary", "status", [], False, None, self.spawn_time, None
-        )
-
-
-class _FakeChangeError(ChangeError):
-    def __init__(self):
-        super().__init__("err", change=_FakeChange())
 
 
 class _FakeResponse:
@@ -141,15 +125,6 @@ def test_update_layer_active(harness, mocked_resource_handler, mocker):
     assert service.is_running() is True
 
     assert harness.model.unit.status == ActiveStatus()
-
-
-def test_update_layer_exception(harness, mocked_resource_handler, mocked_container_replan):
-    harness.begin()
-    mocked_container_replan.side_effect = _FakeChangeError()
-    mocked_event = MagicMock()
-    with pytest.raises(ChangeError):
-        harness.charm._update_layer(mocked_event)
-    assert harness.model.unit.status == BlockedStatus("Failed to replan")
 
 
 @patch("charm.KRH")


### PR DESCRIPTION
Update knative-operator to use the `update_layer` function in chisme, updated tests to match. I removed the update layer test as it is already covered in chisme.
CI would fail until [this pr](https://github.com/canonical/charmed-kubeflow-chisme/pull/25) is merged and published. Tested locally with `git+https://github.com/canonical/charmed-kubeflow-chisme@KF-605/update-layer-handler` in `requirements.txt`