### PR TITLE
feat: pin integration CI juju to 2.9.34

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -57,7 +57,9 @@ jobs:
         with:
           provider: microk8s
           channel: 1.21/stable
-
+          # Pinned to 2.3.34 due to https://bugs.launchpad.net/juju/+bug/1992833
+          # This should be fixed on release of juju 2.3.36 + libjuju 3.0.3
+          bootstrap-options: --agent-version="2.9.34"
       - run: sg microk8s -c "microk8s enable metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"
       - run: juju add-model knative-test
 


### PR DESCRIPTION
This is a temporary fix for https://bugs.launchpad.net/juju/+bug/1992833.
This should be fixed on release of juju 2.3.36 + libjuju 3.0.3
