### PR TITLE
ci: split integration test in two due to limited resources

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -69,7 +69,7 @@ jobs:
         env:
           KUBECONFIG: /home/runner/.kube/config
 
-  observability-integration:
+  integration-observability:
     name: Observability Integration Test
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -44,9 +44,9 @@ jobs:
       - run: sudo apt update && sudo apt install tox
       - run: tox -e ${{ matrix.charm }}-unit
 
-  integration:
+  integration-charm-deployment:
     name: Integration Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out repo
@@ -56,7 +56,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.21/stable
+          channel: 1.22/stable
           # Pinned to 2.3.34 due to https://bugs.launchpad.net/juju/+bug/1992833
           # This should be fixed on release of juju 2.3.36 + libjuju 3.0.3
           bootstrap-options: --agent-version="2.9.34"
@@ -68,6 +68,36 @@ jobs:
         run: tox -vve integration -- --model knative-test --destructive-mode
         env:
           KUBECONFIG: /home/runner/.kube/config
+
+  observability-integration:
+    name: Observability Integration Test
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          channel: 1.22/stable
+          # Pinned to 2.3.34 due to https://bugs.launchpad.net/juju/+bug/1992833
+          # This should be fixed on release of juju 2.3.36 + libjuju 3.0.3
+          bootstrap-options: --agent-version="2.9.34"
+      - run: juju add-model cos-test
+
+      - name: Run integration tests
+
+        run: tox -vve cos-integration -- --model cos-test --destructive-mode
+        env:
+          KUBECONFIG: /home/runner/.kube/config
+
+      - run: kubectl get pod/prometheus-k8s-0 -n knative-test -o=jsonpath='{.status}'
+        if: failure()
+
+      - run: kubectl get pod/knative-operator-0 -nknative-test -o=jsonpath='{.status}'
+        if: failure()
 
       - run: kubectl get all -A
         if: failure()

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -6,7 +6,6 @@ import logging
 
 import pytest
 import requests
-import tenacity
 import yaml
 from pytest_operator.plugin import OpsTest
 
@@ -156,62 +155,3 @@ async def test_cloud_events_player_example(ops_test: OpsTest):
     assert post_req.status_code == 202
     get_req = requests.get(f"{url}/messages", allow_redirects=False, verify=False)
     assert get_req.status_code == 200
-
-
-# knative-operator is the charm that actually talks to prometheus
-# to configure the OpenTelemetry collector to be scraped
-APP_NAME = "knative-operator"
-
-
-async def test_prometheus_grafana_integration(ops_test: OpsTest):
-    """Deploy prometheus and required relations, then test the metrics."""
-    prometheus = "prometheus-k8s"
-    prometheus_scrape = "prometheus-scrape-config-k8s"
-    scrape_config = {"scrape_interval": "30s"}
-
-    # Deploy and relate prometheus
-    await ops_test.model.deploy(prometheus, channel="latest/beta", trust=True)
-    await ops_test.model.deploy(prometheus_scrape, channel="latest/beta", config=scrape_config)
-
-    await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
-    await ops_test.model.add_relation(
-        f"{APP_NAME}:otel-collector", "knative-eventing:otel-collector"
-    )
-    await ops_test.model.add_relation(
-        f"{APP_NAME}:otel-collector", "knative-serving:otel-collector"
-    )
-    await ops_test.model.add_relation(
-        f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
-    )
-
-    await ops_test.model.wait_for_idle(status="active", timeout=60 * 20)
-
-    status = await ops_test.model.get_status()
-    prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"]["address"]
-    log.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
-
-    for attempt in retry_for_5_attempts:
-        log.info(
-            f"Testing prometheus deployment (attempt " f"{attempt.retry_state.attempt_number})"
-        )
-        with attempt:
-            r = requests.get(
-                f"http://{prometheus_unit_ip}:9090/api/v1/query?"
-                f'query=up{{juju_application="{APP_NAME}"}}'
-            )
-            response = json.loads(r.content.decode("utf-8"))
-            response_status = response["status"]
-            log.info(f"Response status is {response_status}")
-            assert response_status == "success"
-
-            response_metric = response["data"]["result"][0]["metric"]
-            assert response_metric["juju_application"] == APP_NAME
-            assert response_metric["juju_model"] == ops_test.model_name
-
-
-# Helper to retry calling a function over 30 seconds or 5 attempts
-retry_for_5_attempts = tenacity.Retrying(
-    stop=(tenacity.stop_after_attempt(5) | tenacity.stop_after_delay(30)),
-    wait=tenacity.wait_exponential(multiplier=1, min=1, max=10),
-    reraise=True,
-)

--- a/tests/test_cos_integration.py
+++ b/tests/test_cos_integration.py
@@ -1,0 +1,118 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+
+import pytest
+import requests
+import tenacity
+import yaml
+from pytest_operator.plugin import OpsTest
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+async def test_build_deploy_knative_charms(ops_test: OpsTest):
+    # Build knative charms
+    charms_path = "./charms/knative"
+    knative_charms = await ops_test.build_charms(
+        f"{charms_path}-operator", f"{charms_path}-serving", f"{charms_path}-eventing"
+    )
+
+    # Deploy knative charms
+    knative_operator_image = "gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.1.0"
+    await ops_test.model.deploy(
+        knative_charms["knative-operator"],
+        application_name="knative-operator",
+        trust=True,
+        resources={"knative-operator-image": knative_operator_image},
+    )
+
+    await ops_test.model.wait_for_idle(
+        ["knative-operator"],
+        status="active",
+        raise_on_blocked=False,
+        timeout=120 * 10,
+    )
+
+    await ops_test.model.deploy(
+        knative_charms["knative-serving"],
+        application_name="knative-serving",
+        config={"namespace": "knative-serving", "istio.gateway.namespace": ops_test.model_name},
+        trust=True,
+    )
+
+    await ops_test.model.deploy(
+        knative_charms["knative-eventing"],
+        application_name="knative-eventing",
+        config={"namespace": "knative-eventing"},
+        trust=True,
+    )
+
+    await ops_test.model.wait_for_idle(
+        ["knative-serving", "knative-eventing"],
+        status="active",
+        raise_on_blocked=False,
+        timeout=120 * 10,
+    )
+
+
+# knative-operator is the charm that actually talks to prometheus
+# to configure the OpenTelemetry collector to be scraped
+APP_NAME = "knative-operator"
+
+
+async def test_prometheus_grafana_integration(ops_test: OpsTest):
+    """Deploy prometheus and required relations, then test the metrics."""
+    prometheus = "prometheus-k8s"
+    prometheus_scrape = "prometheus-scrape-config-k8s"
+    scrape_config = {"scrape_interval": "30s"}
+
+    # Deploy and relate prometheus
+    await ops_test.model.deploy(prometheus, channel="latest/stable", trust=True)
+    await ops_test.model.deploy(prometheus_scrape, channel="latest/stable", config=scrape_config)
+
+    await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
+    await ops_test.model.add_relation(
+        f"{APP_NAME}:otel-collector", "knative-eventing:otel-collector"
+    )
+    await ops_test.model.add_relation(
+        f"{APP_NAME}:otel-collector", "knative-serving:otel-collector"
+    )
+    await ops_test.model.add_relation(
+        f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
+    )
+
+    await ops_test.model.wait_for_idle(status="active", timeout=90 * 10)
+
+    status = await ops_test.model.get_status()
+    prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"]["address"]
+    log.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
+
+    for attempt in retry_for_5_attempts:
+        log.info(
+            f"Testing prometheus deployment (attempt " f"{attempt.retry_state.attempt_number})"
+        )
+        with attempt:
+            r = requests.get(
+                f"http://{prometheus_unit_ip}:9090/api/v1/query?"
+                f'query=up{{juju_application="{APP_NAME}"}}'
+            )
+            response = json.loads(r.content.decode("utf-8"))
+            response_status = response["status"]
+            log.info(f"Response status is {response_status}")
+            assert response_status == "success"
+
+            response_metric = response["data"]["result"][0]["metric"]
+            assert response_metric["juju_application"] == APP_NAME
+            assert response_metric["juju_model"] == ops_test.model_name
+
+
+# Helper to retry calling a function over 30 seconds or 5 attempts
+retry_for_5_attempts = tenacity.Retrying(
+    stop=(tenacity.stop_after_attempt(5) | tenacity.stop_after_delay(30)),
+    wait=tenacity.wait_exponential(multiplier=1, min=1, max=10),
+    reraise=True,
+)

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,11 @@ allowlist_externals = rm
 deps =
     -rtest-requirements.txt
 commands =
-  pytest --show-capture=no --log-cli-level=INFO -vvs --tb=native tests/ {posargs}
+  pytest --show-capture=no --log-cli-level=INFO -vvs --tb=native {posargs} tests/test_bundle.py
+
+[testenv:cos-integration]
+allowlist_externals = rm
+deps =
+    -rtest-requirements.txt
+commands =
+  pytest --show-capture=no --log-cli-level=INFO -vvs --tb=native {posargs} tests/test_cos_integration.py


### PR DESCRIPTION
Github runners have limited resources, which may cause bottlenecks and even errors when running integration tests on demanding charms. Splitting the single integration test job into two prevent this from happening. The new jobs are:
* Integration
* Observability Integration

Merge before #62 