### PR TITLE
tests: pin python-libjuju<3.1 to avoid unsupported version errors

### DIFF
--- a/charms/knative-eventing/requirements-integration.in
+++ b/charms/knative-eventing/requirements-integration.in
@@ -1,6 +1,6 @@
 aiohttp
 jinja2
-juju
+juju<3.1
 pytest-operator
 requests
 -r requirements.txt

--- a/charms/knative-operator/requirements-integration.in
+++ b/charms/knative-operator/requirements-integration.in
@@ -1,6 +1,6 @@
 aiohttp
 jinja2
-juju
+juju<3.1
 pytest-operator
 requests
 -r requirements.txt

--- a/charms/knative-serving/requirements-integration.in
+++ b/charms/knative-serving/requirements-integration.in
@@ -1,6 +1,6 @@
 aiohttp
 jinja2
-juju
+juju<3.1
 pytest-operator
 requests
 -r requirements.txt

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,6 +1,6 @@
 asyncio
 flake8
-juju
+juju<3.1
 lightkube
 pytest-operator
 PyYAML


### PR DESCRIPTION
the juju agent 2.9.34 is not compatible with pythonlib-juju 3.1, causing the following error:
`juju.errors.JujuConnectionError: juju server-version 2.9.34 not supported`
To avoid this, we have to pin to a version below 3.1.