### PR TITLE
feat: refactor knative-operator to make adding additional pebble layers easier

### DIFF
--- a/charms/knative-operator/src/charm.py
+++ b/charms/knative-operator/src/charm.py
@@ -134,8 +134,7 @@ class KnativeOperatorCharm(CharmBase):
             "summary": "knative-operator layer",
             "description": "pebble config layer for knative-operator",
             "services": {
-                # TODO: Change this to be the app name, not the command
-                KNATIVE_OPERATOR_COMMAND: {
+                KNATIVE_OPERATOR: {
                     "override": "replace",
                     "summary": "entrypoint of the knative-operator image",
                     "command": KNATIVE_OPERATOR_COMMAND,

--- a/charms/knative-operator/src/charm.py
+++ b/charms/knative-operator/src/charm.py
@@ -134,10 +134,11 @@ class KnativeOperatorCharm(CharmBase):
             "summary": "knative-operator layer",
             "description": "pebble config layer for knative-operator",
             "services": {
-                KNATIVE_OPERATOR: {
+                # TODO: Change this to be the app name, not the command
+                KNATIVE_OPERATOR_COMMAND: {
                     "override": "replace",
                     "summary": "entrypoint of the knative-operator image",
-                    "command": self._operator_service,
+                    "command": KNATIVE_OPERATOR_COMMAND,
                     "startup": "enabled",
                     "environment": {
                         "POD_NAME": self._app_name,
@@ -163,7 +164,7 @@ class KnativeOperatorCharm(CharmBase):
         # Create a new config layer
         new_layer = self._knative_operator_layer
         if current_layer.services != new_layer.services:
-            self._containers[KNATIVE_OPERATOR].add_layer(self._operator_service, new_layer, combine=True)
+            self._containers[KNATIVE_OPERATOR].add_layer(KNATIVE_OPERATOR, new_layer, combine=True)
             try:
                 logger.info("Pebble plan updated with new configuration, replanning")
                 self._containers[KNATIVE_OPERATOR].replan()

--- a/charms/knative-operator/tests/unit/test_charm.py
+++ b/charms/knative-operator/tests/unit/test_charm.py
@@ -180,7 +180,7 @@ def test_update_layer_exception(
     mocked_container_replan.side_effect = _FakeChangeError()
     mocked_event = MagicMock()
     with pytest.raises(ChangeError):
-        harness.charm._update_layer(mocked_event)
+        harness.charm._update_layer_knative_operator(mocked_event)
     assert harness.model.unit.status == BlockedStatus("Failed to replan")
 
 

--- a/charms/knative-operator/tests/unit/test_charm.py
+++ b/charms/knative-operator/tests/unit/test_charm.py
@@ -15,7 +15,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.pebble import Change, ChangeError, ChangeID
 from ops.testing import Harness
 
-from charm import KnativeOperatorCharm, KNATIVE_OPERATOR
+from charm import KNATIVE_OPERATOR, KnativeOperatorCharm
 
 
 class _FakeChange:

--- a/charms/knative-operator/tests/unit/test_charm.py
+++ b/charms/knative-operator/tests/unit/test_charm.py
@@ -15,7 +15,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.pebble import Change, ChangeError, ChangeID
 from ops.testing import Harness
 
-from charm import KnativeOperatorCharm
+from charm import KnativeOperatorCharm, KNATIVE_OPERATOR
 
 
 class _FakeChange:
@@ -149,7 +149,7 @@ def test_update_layer_active(
 
     expected_plan = {
         "services": {
-            "/ko-app/operator": {
+            KNATIVE_OPERATOR: {
                 "summary": "entrypoint of the knative-operator image",
                 "startup": "enabled",
                 "override": "replace",
@@ -167,7 +167,7 @@ def test_update_layer_active(
     updated_plan = harness.get_container_pebble_plan("knative-operator").to_dict()
     assert expected_plan == updated_plan
 
-    service = harness.model.unit.get_container("knative-operator").get_service("/ko-app/operator")
+    service = harness.model.unit.get_container("knative-operator").get_service(KNATIVE_OPERATOR)
     assert service.is_running() is True
 
     assert harness.model.unit.status == ActiveStatus()

--- a/charms/knative-operator/tests/unit/test_charm.py
+++ b/charms/knative-operator/tests/unit/test_charm.py
@@ -176,12 +176,13 @@ def test_update_layer_active(
 def test_update_layer_exception(
     harness, mocked_resource_handler, mocked_container_replan, mocked_metrics_endpoint_provider
 ):
+    container_name = "knative-operator"
     harness.begin()
     mocked_container_replan.side_effect = _FakeChangeError()
     mocked_event = MagicMock()
     with pytest.raises(ChangeError):
-        harness.charm._update_layer_knative_operator(mocked_event)
-    assert harness.model.unit.status == BlockedStatus("Failed to replan")
+        harness.charm._update_layer(mocked_event, container_name)
+    assert harness.model.unit.status == BlockedStatus(f"Failed to replan for {container_name}")
 
 
 def test_otel_exporter_ip_on_404_apierror(


### PR DESCRIPTION
This is mainly a refactor of the naming of functions within the knative-operator, with the goal of making it easier to add additional pebble layers for knative 1.8's webhook.  There is a slight functional change here, where we change the pebble service name from the path to the application (`/ko-app/operator`) to the application name (`knative-operator`).  Otherwise, this is a non-functional change