### PR TITLE
fix: send gateway info on config changed and remove exception

### DIFF
--- a/charms/knative-serving/tests/unit/test_charm.py
+++ b/charms/knative-serving/tests/unit/test_charm.py
@@ -95,12 +95,16 @@ def test_apply_and_set_status_blocked(
         (
             "ingress-gateway",
             {"istio.gateway.name": "test-name", "istio.gateway.namespace": "test-model"},
-            {"gateway_name": "test-name", "gateway_namespace": "test-model"},
+            {"gateway_name": "test-name", "gateway_namespace": "test-model", "gateway_up": "true"},
         ),
         (
             "local-gateway",
             {"namespace": "test-serving"},
-            {"gateway_name": "knative-local-gateway", "gateway_namespace": "test-serving"},
+            {
+                "gateway_name": "knative-local-gateway",
+                "gateway_namespace": "test-serving",
+                "gateway_up": "true",
+            },
         ),
     ),
 )


### PR DESCRIPTION
We want to send the gateway information on config changed also, not only on relation changed. This commit also removes the exception handling for when the relation does not exist.

Please note this PR should be merged after canonical/istio-operators#249, otherwise the unit tests will fail.

TODO:
- [x] Pull version 0.3 of gateway-info once it gets merged