### PR TITLE
Kf 3784 feat get images (DO NOT MERGE)

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -2,24 +2,19 @@
 # See LICENSE file for licensing details.
 
 import logging
-from pathlib import Path
 import time
-import yaml
+from pathlib import Path
 
 import lightkube.codecs
-from lightkube import Client, ApiError
+import pytest
+import requests
+import yaml
+from lightkube import ApiError, Client
 from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from lightkube.resources.core_v1 import Service
-import pytest
 from pytest_operator.plugin import OpsTest
-import requests
-from tenacity import (
-    Retrying,
-    stop_after_delay,
-    wait_fixed,
-)
-
+from tenacity import Retrying, stop_after_delay, wait_fixed
 
 log = logging.getLogger(__name__)
 

--- a/tests/test_cos_integration.py
+++ b/tests/test_cos_integration.py
@@ -9,7 +9,6 @@ import pytest
 import requests
 import tenacity
 from pytest_operator.plugin import OpsTest
-
 from test_bundle import KNATIVE_OPERATOR_RESOURCES
 
 log = logging.getLogger(__name__)

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
+STATIC_IMAGE_LIST=(
+)
+# dynamic list
+git checkout origin/track/1.8
+IMAGE_LIST=()
+IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}'))
+
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -6,7 +6,7 @@
 STATIC_IMAGE_LIST=(
 )
 # dynamic list
-git checkout origin/track/1.8
+#git checkout origin/track/1.8
 IMAGE_LIST=()
 IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}' | sort --unique))
 

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -8,7 +8,7 @@ STATIC_IMAGE_LIST=(
 # dynamic list
 git checkout origin/track/1.8
 IMAGE_LIST=()
-IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}'))
+IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}' | sort --unique))
 
 printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Repository specific list of images.
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup.

Summary of changes:
- Added script to extract images for stable.
