### PR TITLE
build: bump juju 2.9.44.0, pyyaml->6.0.1

### DIFF
--- a/charms/knative-eventing/requirements-integration.in
+++ b/charms/knative-eventing/requirements-integration.in
@@ -1,7 +1,7 @@
 aiohttp
 jinja2
-# pin juju since we use controller 2.9. Juju (app) 3.0 is end of life and py juju as well
-juju>=2.9.42.3,<3.0
+# Pinning to <3.0 due to compatibility with the 2.9 controller version and 3.0 not being maintained anymore
+juju<3.0
 pytest-operator
 requests
 -r requirements.txt

--- a/charms/knative-eventing/requirements-integration.txt
+++ b/charms/knative-eventing/requirements-integration.txt
@@ -97,7 +97,7 @@ jinja2==3.1.2
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
     #   pytest-operator
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -193,7 +193,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   juju
@@ -223,6 +223,7 @@ ruamel-yaml-clib==0.2.7
     #   ruamel-yaml
 six==1.16.0
     # via
+    #   asttokens
     #   google-auth
     #   kubernetes
     #   macaroonbakery

--- a/charms/knative-eventing/requirements-unit.txt
+++ b/charms/knative-eventing/requirements-unit.txt
@@ -82,7 +82,7 @@ pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
 pytest-mock==3.10.0
     # via -r requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   lightkube

--- a/charms/knative-eventing/requirements.txt
+++ b/charms/knative-eventing/requirements.txt
@@ -40,7 +40,7 @@ ops==2.3.0
     #   charmed-kubeflow-chisme
 ordered-set==4.1.0
     # via deepdiff
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   lightkube
     #   ops

--- a/charms/knative-operator/requirements-integration.in
+++ b/charms/knative-operator/requirements-integration.in
@@ -1,7 +1,7 @@
 aiohttp
 jinja2
-# pin juju since we use controller 2.9. Juju (app) 3.0 is end of life and py juju as well
-juju>=2.9.42.3,<3.0
+# Pinning to <3.0 due to compatibility with the 2.9 controller version and 3.0 not being maintained anymore
+juju<3.0
 pytest-operator
 requests
 -r requirements.txt

--- a/charms/knative-operator/requirements-integration.txt
+++ b/charms/knative-operator/requirements-integration.txt
@@ -97,7 +97,7 @@ jinja2==3.1.2
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
     #   pytest-operator
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -193,7 +193,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   juju
@@ -223,6 +223,7 @@ ruamel-yaml-clib==0.2.7
     #   ruamel-yaml
 six==1.16.0
     # via
+    #   asttokens
     #   google-auth
     #   kubernetes
     #   macaroonbakery

--- a/charms/knative-operator/requirements-unit.txt
+++ b/charms/knative-operator/requirements-unit.txt
@@ -82,7 +82,7 @@ pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
 pytest-mock==3.10.0
     # via -r requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   lightkube

--- a/charms/knative-operator/requirements.txt
+++ b/charms/knative-operator/requirements.txt
@@ -44,7 +44,7 @@ ops==2.3.0
     #   charmed-kubeflow-chisme
 ordered-set==4.1.0
     # via deepdiff
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   lightkube
     #   ops

--- a/charms/knative-serving/requirements-integration.in
+++ b/charms/knative-serving/requirements-integration.in
@@ -1,7 +1,7 @@
 aiohttp
 jinja2
-# pin juju since we use controller 2.9. Juju (app) 3.0 is end of life and py juju as well
-juju>=2.9.42.3,<3.0
+# Pinning to <3.0 due to compatibility with the 2.9 controller version and 3.0 not being maintained anymore
+juju<3.0
 pytest-operator
 requests
 -r requirements.txt

--- a/charms/knative-serving/requirements-integration.txt
+++ b/charms/knative-serving/requirements-integration.txt
@@ -97,7 +97,7 @@ jinja2==3.1.2
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
     #   pytest-operator
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -193,7 +193,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   juju
@@ -223,6 +223,7 @@ ruamel-yaml-clib==0.2.7
     #   ruamel-yaml
 six==1.16.0
     # via
+    #   asttokens
     #   google-auth
     #   kubernetes
     #   macaroonbakery

--- a/charms/knative-serving/requirements-unit.txt
+++ b/charms/knative-serving/requirements-unit.txt
@@ -82,7 +82,7 @@ pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
 pytest-mock==3.10.0
     # via -r requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   lightkube

--- a/charms/knative-serving/requirements.txt
+++ b/charms/knative-serving/requirements.txt
@@ -40,7 +40,7 @@ ops==2.3.0
     #   charmed-kubeflow-chisme
 ordered-set==4.1.0
     # via deepdiff
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   lightkube
     #   ops

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,7 +1,7 @@
 asyncio
 flake8
-# pin juju since we use controller 2.9. Juju (app) 3.0 is end of life and py juju as well
-juju>=2.9.42.3,<3.0
+# Pinning to <3.0 due to compatibility with the 2.9 controller version and 3.0 not being maintained anymore
+juju<3.0
 lightkube
 pytest-operator
 PyYAML

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -65,7 +65,7 @@ jedi==0.18.2
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.42.4
+juju==2.9.44.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -149,7 +149,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements-integration.in
     #   juju
@@ -169,6 +169,7 @@ rsa==4.9
     # via google-auth
 six==1.16.0
     # via
+    #   asttokens
     #   google-auth
     #   kubernetes
     #   macaroonbakery


### PR DESCRIPTION
Bump these package versions to avoid the issues described in https://github.com/canonical/bundle-kubeflow/issues/648.

Part of canonical/bundle-kubeflow#648