### PR TITLE
1.8 Upgrades to version 1.10.x

### DIFF
--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -19,8 +19,8 @@ resources:
   knative-operator-image:
     type: oci-image
     description: OCI image for knative-operator
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.8.1
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.10.1
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.8.1
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.10.1

--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -19,8 +19,8 @@ resources:
   knative-operator-image:
     type: oci-image
     description: OCI image for knative-operator
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.10.1
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.10.3
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.10.1
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.10.3

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -751,12 +751,38 @@ rules:
       - "patch"
       - "watch"
 
+  - apiGroups:
+    - "sources.knative.dev"
+  resources:
+    - "sinkbindings"
+    - "sinkbindings/status"
+    - "sinkbindings/finalizers"
+  verbs:
+    - "get"
+    - "list"
+    - "create"
+    - "update"
+    - "delete"
+    - "patch"
+    - "watch"
+  
   # For leader election
   - apiGroups:
       - "coordination.k8s.io"
     resources:
       - "leases"
     verbs: *everything
+
+  - apiGroups:
+    - ""
+    - "events.k8s.io"
+  resources:
+    - "events"
+  verbs:
+    - "get"
+    - "list"
+    - "create"
+    - "patch"
 
   # Necessary for conversion webhook. These are copied from the serving
   # TODO: Do we really need all these permissions?
@@ -825,8 +851,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.8.1"
-    app.kubernetes.io/version: "1.8.1"
+    operator.knative.dev/release: "v1.10.2"
+    app.kubernetes.io/version: "1.10.2"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -842,8 +868,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.8.1"
-    app.kubernetes.io/version: "1.8.1"
+    operator.knative.dev/release: "v1.10.2"
+    app.kubernetes.io/version: "1.10.2"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -859,8 +885,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.8.1"
-    app.kubernetes.io/version: "1.8.1"
+    operator.knative.dev/release: "v1.10.1"
+    app.kubernetes.io/version: "1.10.1"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -876,8 +902,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.8.1"
-    app.kubernetes.io/version: "1.8.1"
+    operator.knative.dev/release: "v1.10.1"
+    app.kubernetes.io/version: "1.10.1"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -836,10 +836,6 @@ kind: RoleBinding
 metadata:
   namespace: default
   name: knative-operator-webhook
-  labels:
-    eventing.knative.dev/release: devel
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-operator
 subjects:
   - kind: ServiceAccount
     name: knative-operator-webhook

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -835,7 +835,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: default
-  name: operator-webhook
+  name: knative-operator-webhook
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Source: knative/operator/config/rbac/clusterrole_aggregated.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -79,6 +80,7 @@ aggregationRule:
 # Commenting out rules: [] due to https://github.com/gtsystem/lightkube/issues/32
 #rules: [] # Rules are automatically filled in by the controller manager.
 ---
+# Source: knative/operator/config/rbac/role.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -675,6 +677,7 @@ rules:
     verbs:
       - deletecollection
 ---
+# Source: knative/operator/config/rbac/role_binding.yaml
 # TODO: Consider restriction of non-aggregated role to knativeservings namespaces.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -717,7 +720,7 @@ subjects:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# Source: knative/operator/config/rbac/webhook_role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -816,7 +819,7 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
-
+# Source: knative/operator/config/rbac/webhook_role_binding.yaml
 # Copyright 2022 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -858,6 +861,7 @@ subjects:
   name: knative-operator-webhook
   namespace: {{ namespace }}
 ---
+# Source: knative/operator/config/rbac/clusterrole_aggregated_binding.yaml
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -940,6 +944,7 @@ subjects:
     name: {{ name }}-workload
     namespace: {{ namespace }}
 ---
+# Source: knative/operator/config/rbac/webhook_service_account.yaml
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -752,19 +752,19 @@ rules:
       - "watch"
 
   - apiGroups:
-    - "sources.knative.dev"
-  resources:
-    - "sinkbindings"
-    - "sinkbindings/status"
-    - "sinkbindings/finalizers"
-  verbs:
-    - "get"
-    - "list"
-    - "create"
-    - "update"
-    - "delete"
-    - "patch"
-    - "watch"
+      - "sources.knative.dev"
+    resources:
+      - "sinkbindings"
+      - "sinkbindings/status"
+      - "sinkbindings/finalizers"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
   
   # For leader election
   - apiGroups:
@@ -774,15 +774,15 @@ rules:
     verbs: *everything
 
   - apiGroups:
-    - ""
-    - "events.k8s.io"
-  resources:
-    - "events"
-  verbs:
-    - "get"
-    - "list"
-    - "create"
-    - "patch"
+      - ""
+      - "events.k8s.io"
+    resources:
+      - "events"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "patch"
 
   # Necessary for conversion webhook. These are copied from the serving
   # TODO: Do we really need all these permissions?

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -263,6 +263,58 @@ rules:
   - knative-serving-operator
   verbs:
   - delete
+# for contour TLS
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - httpproxies
+  - tlscertificatedelegations
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+  - delete
+  - deletecollection
+  - patch
+# for security-guard
+- apiGroups:
+  - guard.security.knative.dev
+  resources:
+  - guardians
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -751,38 +803,12 @@ rules:
       - "patch"
       - "watch"
 
-  - apiGroups:
-      - "sources.knative.dev"
-    resources:
-      - "sinkbindings"
-      - "sinkbindings/status"
-      - "sinkbindings/finalizers"
-    verbs:
-      - "get"
-      - "list"
-      - "create"
-      - "update"
-      - "delete"
-      - "patch"
-      - "watch"
-  
   # For leader election
   - apiGroups:
       - "coordination.k8s.io"
     resources:
       - "leases"
     verbs: *everything
-
-  - apiGroups:
-      - ""
-      - "events.k8s.io"
-    resources:
-      - "events"
-    verbs:
-      - "get"
-      - "list"
-      - "create"
-      - "patch"
 
   # Necessary for conversion webhook. These are copied from the serving
   # TODO: Do we really need all these permissions?
@@ -809,7 +835,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: default
-  name: knative-operator-webhook
+  name: operator-webhook
+  labels:
+    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-operator
 subjects:
   - kind: ServiceAccount
     name: knative-operator-webhook
@@ -851,8 +881,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.10.2"
-    app.kubernetes.io/version: "1.10.2"
+    operator.knative.dev/release: "v1.10.3"
+    app.kubernetes.io/version: "1.10.3"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -868,8 +898,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.10.2"
-    app.kubernetes.io/version: "1.10.2"
+    operator.knative.dev/release: "v1.10.3"
+    app.kubernetes.io/version: "1.10.3"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -885,8 +915,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.10.1"
-    app.kubernetes.io/version: "1.10.1"
+    operator.knative.dev/release: "v1.10.3"
+    app.kubernetes.io/version: "1.10.3"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -902,8 +932,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.10.1"
-    app.kubernetes.io/version: "1.10.1"
+    operator.knative.dev/release: "v1.10.3"
+    app.kubernetes.io/version: "1.10.3"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charms/knative-operator/src/manifests/config_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/config_manifests.yaml.j2
@@ -1,3 +1,4 @@
+# Source: knative/operator/config/manager/config-logging-configmap.yaml
 # Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,6 +59,7 @@ data:
       }
 
 ---
+# Source: knative/operator/config/manager/config-observability-configmap.yaml
 # Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
@@ -1,3 +1,4 @@
+# Source: knative/operator/config/crd/bases/operator.knative.dev_knativeservings.yaml
 # Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +17,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: knativeservings.operator.knative.dev
+  labels:
+    operator.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-operator
 spec:
   group: operator.knative.dev
   versions:
@@ -402,6 +407,151 @@ spec:
                               If the operator is Exists, the value should be empty, otherwise
                               just a regular string.
                             type: string
+                        type: object
+                      type: array
+                    hostNetwork:
+                      description: Use the host's network namespace if true. Make sure to
+                        understand the security implications if you want to enable it. When
+                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                        automatically.
+                      type: boolean
+                    topologySpreadConstraints:
+                      description: If specified, the pod's topology spread constraints.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching
+                          pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods. Pods
+                              that match this label selector are counted to determine the
+                              number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that relates
+                                    the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In, NotIn,
+                                        Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists or
+                                        DoesNotExist, the values array must be empty. This
+                                        array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field is
+                                  "key", the operator is "In", and the values array contains
+                                  only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods may
+                              be unevenly distributed. It''s the maximum permitted difference
+                              between the number of matching pods in any two topology domains
+                              of a given topology type. For example, in a 3-zone cluster,
+                              MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                              to become 1/1/1; scheduling it onto zone1(zone2) would make
+                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
+                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              It''s a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes that
+                              have a label with this key and identical values are considered
+                              to be in the same topology. We consider each <key, value>
+                              as a "bucket", and try to put balanced number of pods into
+                              each bucket. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal with a
+                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                              (default) tells the scheduler not to schedule it - ScheduleAnyway
+                              tells the scheduler to still schedule it It''s considered
+                              as "Unsatisfiable" if and only if placing incoming pod on
+                              any topology violates "MaxSkew". For example, in a 3-zone
+                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
+                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
+                              other words, the cluster can still be imbalanced, but scheduler
+                              won''t make it *more* imbalanced. It''s a required field.'
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                    version:
+                      description: Version the cluster should be on.
+                      type: string
+                    volumeMounts:
+                      description: VolumeMounts allows configuration of additional VolumeMounts
+                        on the output StatefulSet definition. VolumeMounts specified will
+                        be appended to other VolumeMounts in the alertmanager container,
+                        that are generated as a result of StorageSpec objects.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within
+                          a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume should
+                              be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are propagated
+                              from the host to container and the other way around. When
+                              not set, MountPropagationNone is used. This field is beta
+                              in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which the
+                              container's volume should be mounted. Behaves similarly to
+                              SubPath but environment variable references $(VAR_NAME) are
+                              expanded using the container's environment. Defaults to ""
+                              (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
                         type: object
                       type: array
                     affinity:
@@ -1322,6 +1472,106 @@ spec:
                               If the operator is Exists, the value should be empty, otherwise
                               just a regular string.
                             type: string
+                        type: object
+                      type: array
+                    hostNetwork:
+                      description: Use the host's network namespace if true. Make sure to
+                        understand the security implications if you want to enable it. When
+                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                        automatically.
+                      type: boolean
+                    topologySpreadConstraints:
+                      description: If specified, the pod's topology spread constraints.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching
+                          pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods. Pods
+                              that match this label selector are counted to determine the
+                              number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that relates
+                                    the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In, NotIn,
+                                        Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists or
+                                        DoesNotExist, the values array must be empty. This
+                                        array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field is
+                                  "key", the operator is "In", and the values array contains
+                                  only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods may
+                              be unevenly distributed. It''s the maximum permitted difference
+                              between the number of matching pods in any two topology domains
+                              of a given topology type. For example, in a 3-zone cluster,
+                              MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                              to become 1/1/1; scheduling it onto zone1(zone2) would make
+                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
+                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              It''s a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes that
+                              have a label with this key and identical values are considered
+                              to be in the same topology. We consider each <key, value>
+                              as a "bucket", and try to put balanced number of pods into
+                              each bucket. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal with a
+                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                              (default) tells the scheduler not to schedule it - ScheduleAnyway
+                              tells the scheduler to still schedule it It''s considered
+                              as "Unsatisfiable" if and only if placing incoming pod on
+                              any topology violates "MaxSkew". For example, in a 3-zone
+                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
+                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
+                              other words, the cluster can still be imbalanced, but scheduler
+                              won''t make it *more* imbalanced. It''s a required field.'
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
                         type: object
                       type: array
                     affinity:
@@ -2066,6 +2316,16 @@ spec:
                         type: string
                     type: object
                 type: object
+              security:
+                description: The security configuration for Knative Serving
+                properties:
+                  securityGuard:
+                    description: Security Guard settings
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
               manifests:
                 description: A list of serving manifests, which will be installed
                   by the operator
@@ -2183,6 +2443,7 @@ spec:
           namespace: default
           path: /resource-conversion
 ---
+# Source: knative/operator/config/crd/bases/operator.knative.dev_knativeeventings.yaml
 # Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2201,6 +2462,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: knativeeventings.operator.knative.dev
+  labels:
+    operator.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-operator
 spec:
   group: operator.knative.dev
   versions:
@@ -2576,6 +2841,151 @@ spec:
                               If the operator is Exists, the value should be empty, otherwise
                               just a regular string.
                             type: string
+                        type: object
+                      type: array
+                    hostNetwork:
+                      description: Use the host's network namespace if true. Make sure to
+                        understand the security implications if you want to enable it. When
+                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                        automatically.
+                      type: boolean
+                    topologySpreadConstraints:
+                      description: If specified, the pod's topology spread constraints.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching
+                          pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods. Pods
+                              that match this label selector are counted to determine the
+                              number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that relates
+                                    the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In, NotIn,
+                                        Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists or
+                                        DoesNotExist, the values array must be empty. This
+                                        array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field is
+                                  "key", the operator is "In", and the values array contains
+                                  only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods may
+                              be unevenly distributed. It''s the maximum permitted difference
+                              between the number of matching pods in any two topology domains
+                              of a given topology type. For example, in a 3-zone cluster,
+                              MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                              to become 1/1/1; scheduling it onto zone1(zone2) would make
+                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
+                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              It''s a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes that
+                              have a label with this key and identical values are considered
+                              to be in the same topology. We consider each <key, value>
+                              as a "bucket", and try to put balanced number of pods into
+                              each bucket. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal with a
+                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                              (default) tells the scheduler not to schedule it - ScheduleAnyway
+                              tells the scheduler to still schedule it It''s considered
+                              as "Unsatisfiable" if and only if placing incoming pod on
+                              any topology violates "MaxSkew". For example, in a 3-zone
+                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
+                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
+                              other words, the cluster can still be imbalanced, but scheduler
+                              won''t make it *more* imbalanced. It''s a required field.'
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                    version:
+                      description: Version the cluster should be on.
+                      type: string
+                    volumeMounts:
+                      description: VolumeMounts allows configuration of additional VolumeMounts
+                        on the output StatefulSet definition. VolumeMounts specified will
+                        be appended to other VolumeMounts in the alertmanager container,
+                        that are generated as a result of StorageSpec objects.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within
+                          a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume should
+                              be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are propagated
+                              from the host to container and the other way around. When
+                              not set, MountPropagationNone is used. This field is beta
+                              in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which the
+                              container's volume should be mounted. Behaves similarly to
+                              SubPath but environment variable references $(VAR_NAME) are
+                              expanded using the container's environment. Defaults to ""
+                              (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
                         type: object
                       type: array
                     affinity:
@@ -3496,6 +3906,106 @@ spec:
                               If the operator is Exists, the value should be empty, otherwise
                               just a regular string.
                             type: string
+                        type: object
+                      type: array
+                    hostNetwork:
+                      description: Use the host's network namespace if true. Make sure to
+                        understand the security implications if you want to enable it. When
+                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                        automatically.
+                      type: boolean
+                    topologySpreadConstraints:
+                      description: If specified, the pod's topology spread constraints.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching
+                          pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods. Pods
+                              that match this label selector are counted to determine the
+                              number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that relates
+                                    the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In, NotIn,
+                                        Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists or
+                                        DoesNotExist, the values array must be empty. This
+                                        array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field is
+                                  "key", the operator is "In", and the values array contains
+                                  only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods may
+                              be unevenly distributed. It''s the maximum permitted difference
+                              between the number of matching pods in any two topology domains
+                              of a given topology type. For example, in a 3-zone cluster,
+                              MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                              to become 1/1/1; scheduling it onto zone1(zone2) would make
+                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
+                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              It''s a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes that
+                              have a label with this key and identical values are considered
+                              to be in the same topology. We consider each <key, value>
+                              as a "bucket", and try to put balanced number of pods into
+                              each bucket. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal with a
+                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                              (default) tells the scheduler not to schedule it - ScheduleAnyway
+                              tells the scheduler to still schedule it It''s considered
+                              as "Unsatisfiable" if and only if placing incoming pod on
+                              any topology violates "MaxSkew". For example, in a 3-zone
+                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
+                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
+                              other words, the cluster can still be imbalanced, but scheduler
+                              won''t make it *more* imbalanced. It''s a required field.'
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
                         type: object
                       type: array
                     affinity:

--- a/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
@@ -17,10 +17,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: knativeservings.operator.knative.dev
-  labels:
-    operator.knative.dev/release: devel
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-operator
 spec:
   group: operator.knative.dev
   versions:
@@ -2462,10 +2458,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: knativeeventings.operator.knative.dev
-  labels:
-    operator.knative.dev/release: devel
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-operator
 spec:
   group: operator.knative.dev
   versions:

--- a/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
@@ -19,7 +19,7 @@ metadata:
   namespace: {{ namespace }}
   labels:
     app.kubernetes.io/component: webhook
-    operator.knative.dev/release: "v1.10.1"
-    app.kubernetes.io/version: "1.10.1"
+    operator.knative.dev/release: "v1.10.3"
+    app.kubernetes.io/version: "1.10.3"
     app.kubernetes.io/part-of: knative-operator
 # The data is populated at install time.

--- a/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
@@ -1,3 +1,4 @@
+# Source: knative/operator/config/webhook/webhook-secret.yaml
 # Copyright 2022 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
@@ -19,7 +19,7 @@ metadata:
   namespace: {{ namespace }}
   labels:
     app.kubernetes.io/component: webhook
-    operator.knative.dev/release: "v1.8.1"
-    app.kubernetes.io/version: "1.8.1"
+    operator.knative.dev/release: "v1.10.1"
+    app.kubernetes.io/version: "1.10.1"
     app.kubernetes.io/part-of: knative-operator
 # The data is populated at install time.

--- a/charms/knative-operator/src/manifests/service_account.yaml.j2
+++ b/charms/knative-operator/src/manifests/service_account.yaml.j2
@@ -1,3 +1,4 @@
+# Source: knative/operator/config/rbac/service_account.yaml
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/charms/knative-operator/src/manifests/webhook-service.yaml
+++ b/charms/knative-operator/src/manifests/webhook-service.yaml
@@ -1,3 +1,4 @@
+# Source: knative/operator/config/webhook/webhook-service.yaml
 # Copyright 2022 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.8.0"
+    default: "1.10.2"
     description: Version of knative-serving component.
     type: string
   namespace:


### PR DESCRIPTION
Upgrade with the following versions:
- knative-operator to latest 1.10 being 1.10.3
- knative-serving to 1.10.2
- knative-eventing to 1.10.1

Kubeflow 1.8 Dependencies versions reference: kubeflow/manifests#2450
The minor versions for `knative-serving` and `knative-eventing` are to align with upstream: reference in PR kubeflow/manifests#2486