### PR TITLE
feat: get images on main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: File a bug report
+labels: ["Type: bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charms. If not, please switch to the newest revision prior to
+        posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to help explain your problem. If applicable, add screenshots to
+        help explain the problem you are facing.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide a step-by-step instruction of how to reproduce the behavior.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju relate ...`
+        3. `juju status --relations`
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs
+        at https://juju.is/docs/olm/juju-logs
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -13,7 +13,7 @@ IMAGE_LIST=()
 IMAGE_LIST+=($(find . -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}' | sort --unique))
 # obtain knative eventing version and corresponding knative release information
-KNATIVE_EVENTING_VERSION=$(yq '.options.version.default' ./charms/knative-eventing/config.yaml)
+KNATIVE_EVENTING_VERSION=$(yq -N '.options.version.default' ./charms/knative-eventing/config.yaml)
 KNATIVE_EVENTING_REPO_DOWNLOAD_URL=https://github.com/knative/eventing/releases/download/
 EVENTING_IMAGE_LIST=()
 wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSION}/eventing-core.yaml"
@@ -21,7 +21,7 @@ EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./
 wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSION}/eventing.yaml"
 EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./eventing.yaml))
 # obtain knative serving version and corresponding knative release information
-KNATIVE_SERVING_VERSION=$(yq '.options.version.default' ./charms/knative-serving/config.yaml)
+KNATIVE_SERVING_VERSION=$(yq -N '.options.version.default' ./charms/knative-serving/config.yaml)
 KNATIVE_SERVING_REPO_DOWNLOAD_URL=https://github.com/knative/serving/releases/download/
 SERVING_IMAGE_LIST=()
 wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-core.yaml"
@@ -37,17 +37,23 @@ SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./s
 wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-post-install-jobs.yaml"
 SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-post-install-jobs.yaml))
 # obtain net istio images based on hardcoded version
-NET_ISTIO_VERSION=${KNATIVE_SERVING_VERSION}
-
+NET_ISTIO_VERSION="${KNATIVE_SERVING_VERSION}"
 # NOTE: for KNative Serving version 1.10.2 Net Istio version must be set to 1.11.0
 #       this need to be reviewed if KNative Serving version is changed
-if [ KNATIVE_SERVING_VERSION == "1.10.2" ]; then
+if [ $KNATIVE_SERVING_VERSION == "1.10.2" ]; then
   NET_ISTIO_VERSION="1.11.0"
 fi
 NET_ISTIO_REPO_DOWNLOAD_URL=https://github.com/knative-extensions/net-istio/releases/download/
 NET_ISTIO_IMAGE_LIST=()
 wget -q "${NET_ISTIO_REPO_DOWNLOAD_URL}knative-v${NET_ISTIO_VERSION}/net-istio.yaml"
 NET_ISTIO_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./net-istio.yaml))
+
+# remove nulls from arrays
+del_null="null"
+EVENTING_IMAGE_LIST=("${EVENTING_IMAGE_LIST[@]/$del_null}")
+SERVING_IMAGE_LIST=("${SERVING_IMAGE_LIST[@]/$del_null}")
+NET_ISTIO_IMAGE_LIST=("${NET_ISTIO_IMAGE_LIST[@]/$del_null}")
+IMAGE_LIST=("${IMAGE_LIST[@]/$del_null}")
 
 # TO-DO not printing static list
 #printf "%s\n" "${STATIC_IMAGE_LIST[@]}" | sort -u

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -6,16 +6,13 @@
 STATIC_IMAGE_LIST=(
 # manual addition based on https://github.com/canonical/knative-operators/issues/137
 # TO-DO: This images are present in deployment, but either cannot be found in YAMLs and/or their SHA do not match the deployed versions
-gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:2b484d982ef1a5d6ff93c46d3e45f51c2605c2e3ed766e20247d1727eb5ce918
-gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:59b6a46d3b55a03507c76a3afe8a4ee5f1a38f1130fd3d65c9fe57fff583fa8d
 gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:59431cf8337532edcd9a4bcd030591866cc867f13bee875d81757c960a53668d
-gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:d0095787bc1687e2d8180b36a66997733a52f8c49c3e7751f067813e3fb54b66
 )
 # dynamic list
 IMAGE_LIST=()
 IMAGE_LIST+=($(find . -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}' | sort --unique))
-# obtain knatice eventing version and corresponding knative release information
+# obtain knative eventing version and corresponding knative release information
 KNATIVE_EVENTING_VERSION=$(yq '.options.version.default' ./charms/knative-eventing/config.yaml)
 KNATIVE_EVENTING_REPO_DOWNLOAD_URL=https://github.com/knative/eventing/releases/download/
 EVENTING_IMAGE_LIST=()
@@ -28,19 +25,33 @@ KNATIVE_SERVING_VERSION=$(yq '.options.version.default' ./charms/knative-serving
 KNATIVE_SERVING_REPO_DOWNLOAD_URL=https://github.com/knative/serving/releases/download/
 SERVING_IMAGE_LIST=()
 wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-core.yaml"
-SERVING_IMAGE_LIST+=($(yq 'select(di == 28) | .spec.image' ./serving-core.yaml))
-SERVING_IMAGE_LIST+=($(yq 'select(di == 31) | .data.queue-sidecar-image' ./serving-core.yaml))
-SERVING_IMAGE_LIST+=($(yq -N 'select(di > 31) | .spec.template.spec.containers | .[] | .image' ./serving-core.yaml))
+SERVING_IMAGE_LIST+=($(yq -N '.spec.image' ./serving-core.yaml))
+SERVING_IMAGE_LIST+=($(yq -N '.data.queue-sidecar-image' ./serving-core.yaml))
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-core.yaml))
 wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-hpa.yaml"
-SERVING_IMAGE_LIST+=($(yq 'select(di == 0) | .spec.template.spec.containers | .[] | .image' ./serving-hpa.yaml))
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-hpa.yaml))
 wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-default-domain.yaml"
-SERVING_IMAGE_LIST+=($(yq 'select(di == 0) | .spec.template.spec.containers | .[] | .image' ./serving-default-domain.yaml))
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-default-domain.yaml))
 wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-storage-version-migration.yaml"
-SERVING_IMAGE_LIST+=($(yq 'select(di == 0) | .spec.template.spec.containers | .[] | .image' ./serving-storage-version-migration.yaml))
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-storage-version-migration.yaml))
 wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-post-install-jobs.yaml"
-SERVING_IMAGE_LIST+=($(yq 'select(di == 0) | .spec.template.spec.containers | .[] | .image' ./serving-post-install-jobs.yaml))
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-post-install-jobs.yaml))
+# obtain net istio images based on hardcoded version
+NET_ISTIO_VERSION=${KNATIVE_SERVING_VERSION}
 
-# NOTE: not printing static list
+# NOTE: for KNative Serving version 1.10.2 Net Istio version must be set to 1.11.0
+#       this need to be reviewed if KNative Serving version is changed
+if [ KNATIVE_SERVING_VERSION == "1.10.2" ]; then
+  NET_ISTIO_VERSION="1.11.0"
+fi
+NET_ISTIO_REPO_DOWNLOAD_URL=https://github.com/knative-extensions/net-istio/releases/download/
+NET_ISTIO_IMAGE_LIST=()
+wget -q "${NET_ISTIO_REPO_DOWNLOAD_URL}knative-v${NET_ISTIO_VERSION}/net-istio.yaml"
+NET_ISTIO_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./net-istio.yaml))
+
+# TO-DO not printing static list
+#printf "%s\n" "${STATIC_IMAGE_LIST[@]}" | sort -u
 printf "%s\n" "${EVENTING_IMAGE_LIST[@]}" | sort -u
 printf "%s\n" "${SERVING_IMAGE_LIST[@]}" | sort -u
+printf "%s\n" "${NET_ISTIO_IMAGE_LIST[@]}" | sort -u
 printf "%s\n" "${IMAGE_LIST[@]}" | sort -u

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 #
 # This script returns list of container images that are managed by this charm and/or its workload
-#
-# static list
-STATIC_IMAGE_LIST=(
-# manual addition based on https://github.com/canonical/knative-operators/issues/137
-# TO-DO: This images are present in deployment, but either cannot be found in YAMLs and/or their SHA do not match the deployed versions
-gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:59431cf8337532edcd9a4bcd030591866cc867f13bee875d81757c960a53668d
-)
-# dynamic list
+
 IMAGE_LIST=()
 IMAGE_LIST+=($(find . -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}' | sort --unique))
@@ -55,8 +48,6 @@ SERVING_IMAGE_LIST=("${SERVING_IMAGE_LIST[@]/$del_null}")
 NET_ISTIO_IMAGE_LIST=("${NET_ISTIO_IMAGE_LIST[@]/$del_null}")
 IMAGE_LIST=("${IMAGE_LIST[@]/$del_null}")
 
-# TO-DO not printing static list
-#printf "%s\n" "${STATIC_IMAGE_LIST[@]}" | sort -u
 printf "%s\n" "${EVENTING_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
 printf "%s\n" "${SERVING_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
 printf "%s\n" "${NET_ISTIO_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -5,13 +5,7 @@
 # static list
 STATIC_IMAGE_LIST=(
 # manual addition based on https://github.com/canonical/knative-operators/issues/137
-gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:33ea8a657b974d7bf3d94c0b601a4fc287c1fb33430b3dda028a1a189e3d9526
-gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:f4a9dfce9eec5272c90a19dbdf791fffc98bc5a6649ee85cb8a29bd5145635b1
-gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:cbc452f35842cc8a78240642adc1ebb11a4c4d7c143c8277edb49012f6cfc5d3
-gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:3ced549336c7ccf3bb2adf23a558eb55bd1aec7be17837062d21c749dfce8ce5
-gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:e17bbdf951868359424cd0a0465da8ef44c66ba7111292444ce555c83e280f1a
-gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:c5d3664780b394f6d3e546eb94c972965fbd9357da5e442c66455db7ca94124c
-gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:c9c582f530155d22c01b43957ae0dba549b1cc903f77ec6cc1acb9ae9085be62
+# TO-DO: This images are present in deployment, but either cannot be found in YAMLs and/or their SHA do not match the deployed versions
 gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:2b484d982ef1a5d6ff93c46d3e45f51c2605c2e3ed766e20247d1727eb5ce918
 gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:59b6a46d3b55a03507c76a3afe8a4ee5f1a38f1130fd3d65c9fe57fff583fa8d
 gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:59431cf8337532edcd9a4bcd030591866cc867f13bee875d81757c960a53668d
@@ -21,18 +15,32 @@ gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
 IMAGE_LIST=()
 IMAGE_LIST+=($(find . -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}' | sort --unique))
-# obtaint knative serving version and corresponding knative release information
+# obtain knatice eventing version and corresponding knative release information
+KNATIVE_EVENTING_VERSION=$(yq '.options.version.default' ./charms/knative-eventing/config.yaml)
+KNATIVE_EVENTING_REPO_DOWNLOAD_URL=https://github.com/knative/eventing/releases/download/
+EVENTING_IMAGE_LIST=()
+wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSION}/eventing-core.yaml"
+EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./eventing-core.yaml))
+wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSION}/eventing.yaml"
+EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./eventing.yaml))
+# obtain knative serving version and corresponding knative release information
 KNATIVE_SERVING_VERSION=$(yq '.options.version.default' ./charms/knative-serving/config.yaml)
-KNATIVE_REPO_DOWNLOAD_URL=https://github.com/knative/serving/releases/download/
-wget -q "${KNATIVE_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-core.yaml"
+KNATIVE_SERVING_REPO_DOWNLOAD_URL=https://github.com/knative/serving/releases/download/
 SERVING_IMAGE_LIST=()
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-core.yaml"
 SERVING_IMAGE_LIST+=($(yq 'select(di == 28) | .spec.image' ./serving-core.yaml))
 SERVING_IMAGE_LIST+=($(yq 'select(di == 31) | .data.queue-sidecar-image' ./serving-core.yaml))
 SERVING_IMAGE_LIST+=($(yq -N 'select(di > 31) | .spec.template.spec.containers | .[] | .image' ./serving-core.yaml))
-wget -q "${KNATIVE_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-hpa.yaml"
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-hpa.yaml"
 SERVING_IMAGE_LIST+=($(yq 'select(di == 0) | .spec.template.spec.containers | .[] | .image' ./serving-hpa.yaml))
-wget -q "${KNATIVE_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-default-domain.yaml"
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-default-domain.yaml"
 SERVING_IMAGE_LIST+=($(yq 'select(di == 0) | .spec.template.spec.containers | .[] | .image' ./serving-default-domain.yaml))
-printf "%s\n" "${SERVING_IMAGE_LIST[@]}"
-printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
-printf "%s\n" "${IMAGE_LIST[@]}"
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-storage-version-migration.yaml"
+SERVING_IMAGE_LIST+=($(yq 'select(di == 0) | .spec.template.spec.containers | .[] | .image' ./serving-storage-version-migration.yaml))
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-post-install-jobs.yaml"
+SERVING_IMAGE_LIST+=($(yq 'select(di == 0) | .spec.template.spec.containers | .[] | .image' ./serving-post-install-jobs.yaml))
+
+# NOTE: not printing static list
+printf "%s\n" "${EVENTING_IMAGE_LIST[@]}" | sort -u
+printf "%s\n" "${SERVING_IMAGE_LIST[@]}" | sort -u
+printf "%s\n" "${IMAGE_LIST[@]}" | sort -u

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
+STATIC_IMAGE_LIST=(
+# manual addition based on https://github.com/canonical/knative-operators/issues/137
+gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:33ea8a657b974d7bf3d94c0b601a4fc287c1fb33430b3dda028a1a189e3d9526
+gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:f4a9dfce9eec5272c90a19dbdf791fffc98bc5a6649ee85cb8a29bd5145635b1
+gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:cbc452f35842cc8a78240642adc1ebb11a4c4d7c143c8277edb49012f6cfc5d3
+gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:3ced549336c7ccf3bb2adf23a558eb55bd1aec7be17837062d21c749dfce8ce5
+gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:e17bbdf951868359424cd0a0465da8ef44c66ba7111292444ce555c83e280f1a
+gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:c5d3664780b394f6d3e546eb94c972965fbd9357da5e442c66455db7ca94124c
+gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:c9c582f530155d22c01b43957ae0dba549b1cc903f77ec6cc1acb9ae9085be62
+gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:2b484d982ef1a5d6ff93c46d3e45f51c2605c2e3ed766e20247d1727eb5ce918
+gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:59b6a46d3b55a03507c76a3afe8a4ee5f1a38f1130fd3d65c9fe57fff583fa8d
+gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:59431cf8337532edcd9a4bcd030591866cc867f13bee875d81757c960a53668d
+gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:d0095787bc1687e2d8180b36a66997733a52f8c49c3e7751f067813e3fb54b66
+gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:c3bbf3a96920048869dcab8e133e00f59855670b8a0bbca3d72ced2f512eb5e1
+gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:7003443f0faabbaca12249aa16b73fa171bddf350abd826dd93b06f5080a146d
+gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:caae5e34b4cb311ed8551f2778cfca566a77a924a59b775bd516fa8b5e3c1d7f
+gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:38f9557f4d61ec79cc2cdbe76da8df6c6ae5f978a50a2847c22cc61aa240da95
+gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:a4ba0076df2efaca2eed561339e21b3a4ca9d90167befd31de882bff69639470
+gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:763d648bf1edee2b4471b0e211dbc53ba2d28f92e4dae28ccd39af7185ef2c96
+gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:bc13765ba4895c0fa318a065392d05d0adc0e20415c739e0aacb3f56140bf9ae
+)
+# dynamic list
+IMAGE_LIST=()
+IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}' | sort --unique))
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -54,3 +54,7 @@ printf "%s\n" "${EVENTING_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
 printf "%s\n" "${SERVING_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
 printf "%s\n" "${NET_ISTIO_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
 printf "%s\n" "${IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
+
+rm eventing-core.yaml eventing-post-install.yaml eventing.yaml net-istio.yaml \
+  serving-core.yaml serving-default-domain.yaml serving-hpa.yaml \
+  serving-post-install-jobs.yaml serving-storage-version-migration.yaml

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -13,6 +13,8 @@ wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSI
 EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./eventing-core.yaml))
 wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSION}/eventing.yaml"
 EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./eventing.yaml))
+wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSION}/eventing-post-install.yaml"
+EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./eventing-post-install.yaml))
 # obtain knative serving version and corresponding knative release information
 KNATIVE_SERVING_VERSION=$(yq -N '.options.version.default' ./charms/knative-serving/config.yaml)
 KNATIVE_SERVING_REPO_DOWNLOAD_URL=https://github.com/knative/serving/releases/download/

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -57,7 +57,7 @@ IMAGE_LIST=("${IMAGE_LIST[@]/$del_null}")
 
 # TO-DO not printing static list
 #printf "%s\n" "${STATIC_IMAGE_LIST[@]}" | sort -u
-printf "%s\n" "${EVENTING_IMAGE_LIST[@]}" | sort -u
-printf "%s\n" "${SERVING_IMAGE_LIST[@]}" | sort -u
-printf "%s\n" "${NET_ISTIO_IMAGE_LIST[@]}" | sort -u
-printf "%s\n" "${IMAGE_LIST[@]}" | sort -u
+printf "%s\n" "${EVENTING_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
+printf "%s\n" "${SERVING_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
+printf "%s\n" "${NET_ISTIO_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
+printf "%s\n" "${IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -26,6 +26,7 @@ gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:bc13765ba4895c0fa
 )
 # dynamic list
 IMAGE_LIST=()
+IMAGE_LIST+=($(find . -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}' | sort --unique))
 printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
# Description
Refer to this issue for more details: https://github.com/canonical/bundle-kubeflow/issues/679
Issue in this repo: https://github.com/canonical/knative-operators/issues/142

# Summary of changes:
- Added script that produces list of container images managed by charms in this repository and/or by corresponding workloads. Image list is a combination of static and dynamic lists.
- Updated script to extract version and use it to download YAML files. Parse those files to extract images.

To extract KNative Serving images correctly the following 3 files from KNative repository will be parsed for images based on version in `./charms/knative-serving/config.yaml`. These files are located in `https://github.com/knative/serving/releases/download/knative-v<VERSION>/`
- `serving-core.yaml`
- `serving-hpa.yaml`
- `serving-default-domain.yaml`

NOTE: @kimwnasptd Other images, eg. that belong to eventing component, will have to stay in static list.

# Testing

Deployed Charmed Kubefrom from `latest/edge` and verified that all images that are pulled match images in static list of image retrieval script:
```
knative-operator                                    active       1  knative-operator         1.8/edge      257  10.152.183.180  no       
knative-serving                                     active       1  knative-serving          1.8/edge      282  10.152.183.202  no       
kserve-controller                                   active       1  kserve-controller        0.10/edge     297  10.152.183.122  no       
```
```
$ microk8s ctr images list | grep knative
gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:33ea8a657b974d7bf3d94c0b601a4fc287c1fb33430b3dda028a1a189e3d9526                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:33ea8a657b974d7bf3d94c0b601a4fc287c1fb33430b3dda028a1a189e3d9526 15.8 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:f4a9dfce9eec5272c90a19dbdf791fffc98bc5a6649ee85cb8a29bd5145635b1                                    application/vnd.docker.distribution.manifest.list.v2+json sha256:f4a9dfce9eec5272c90a19dbdf791fffc98bc5a6649ee85cb8a29bd5145635b1 15.8 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:cbc452f35842cc8a78240642adc1ebb11a4c4d7c143c8277edb49012f6cfc5d3                                        application/vnd.docker.distribution.manifest.list.v2+json sha256:cbc452f35842cc8a78240642adc1ebb11a4c4d7c143c8277edb49012f6cfc5d3 17.0 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:3ced549336c7ccf3bb2adf23a558eb55bd1aec7be17837062d21c749dfce8ce5                      application/vnd.docker.distribution.manifest.list.v2+json sha256:3ced549336c7ccf3bb2adf23a558eb55bd1aec7be17837062d21c749dfce8ce5 16.6 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:e17bbdf951868359424cd0a0465da8ef44c66ba7111292444ce555c83e280f1a                      application/vnd.docker.distribution.manifest.list.v2+json sha256:e17bbdf951868359424cd0a0465da8ef44c66ba7111292444ce555c83e280f1a 16.6 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:c5d3664780b394f6d3e546eb94c972965fbd9357da5e442c66455db7ca94124c                                  application/vnd.docker.distribution.manifest.list.v2+json sha256:c5d3664780b394f6d3e546eb94c972965fbd9357da5e442c66455db7ca94124c 16.4 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:c9c582f530155d22c01b43957ae0dba549b1cc903f77ec6cc1acb9ae9085be62                                           application/vnd.docker.distribution.manifest.list.v2+json sha256:c9c582f530155d22c01b43957ae0dba549b1cc903f77ec6cc1acb9ae9085be62 16.6 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:2b484d982ef1a5d6ff93c46d3e45f51c2605c2e3ed766e20247d1727eb5ce918                                       application/vnd.docker.distribution.manifest.list.v2+json sha256:2b484d982ef1a5d6ff93c46d3e45f51c2605c2e3ed766e20247d1727eb5ce918 16.8 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:59b6a46d3b55a03507c76a3afe8a4ee5f1a38f1130fd3d65c9fe57fff583fa8d                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:59b6a46d3b55a03507c76a3afe8a4ee5f1a38f1130fd3d65c9fe57fff583fa8d 15.3 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:59431cf8337532edcd9a4bcd030591866cc867f13bee875d81757c960a53668d                   application/vnd.docker.distribution.manifest.list.v2+json sha256:59431cf8337532edcd9a4bcd030591866cc867f13bee875d81757c960a53668d 11.5 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:d0095787bc1687e2d8180b36a66997733a52f8c49c3e7751f067813e3fb54b66                   application/vnd.docker.distribution.manifest.list.v2+json sha256:d0095787bc1687e2d8180b36a66997733a52f8c49c3e7751f067813e3fb54b66 11.5 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:c3bbf3a96920048869dcab8e133e00f59855670b8a0bbca3d72ced2f512eb5e1                                          application/vnd.docker.distribution.manifest.list.v2+json sha256:c3bbf3a96920048869dcab8e133e00f59855670b8a0bbca3d72ced2f512eb5e1 15.9 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:7003443f0faabbaca12249aa16b73fa171bddf350abd826dd93b06f5080a146d                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:7003443f0faabbaca12249aa16b73fa171bddf350abd826dd93b06f5080a146d 15.9 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:caae5e34b4cb311ed8551f2778cfca566a77a924a59b775bd516fa8b5e3c1d7f                                         application/vnd.docker.distribution.manifest.list.v2+json sha256:caae5e34b4cb311ed8551f2778cfca566a77a924a59b775bd516fa8b5e3c1d7f 16.1 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:38f9557f4d61ec79cc2cdbe76da8df6c6ae5f978a50a2847c22cc61aa240da95                                         application/vnd.docker.distribution.manifest.list.v2+json sha256:38f9557f4d61ec79cc2cdbe76da8df6c6ae5f978a50a2847c22cc61aa240da95 17.8 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:a4ba0076df2efaca2eed561339e21b3a4ca9d90167befd31de882bff69639470                             application/vnd.docker.distribution.manifest.list.v2+json sha256:a4ba0076df2efaca2eed561339e21b3a4ca9d90167befd31de882bff69639470 15.3 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:763d648bf1edee2b4471b0e211dbc53ba2d28f92e4dae28ccd39af7185ef2c96                                     application/vnd.docker.distribution.manifest.list.v2+json sha256:763d648bf1edee2b4471b0e211dbc53ba2d28f92e4dae28ccd39af7185ef2c96 15.8 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:bc13765ba4895c0fa318a065392d05d0adc0e20415c739e0aacb3f56140bf9ae                                            application/vnd.docker.distribution.manifest.list.v2+json sha256:bc13765ba4895c0fa318a065392d05d0adc0e20415c739e0aacb3f56140bf9ae 15.7 MiB  linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x                                           io.cri-containerd.image=managed 
registry.jujucharms.com/charm/dvbszzgs66b9bbmcs48joij6tx51m16cr36zp/knative-operator-image@sha256:cc7ea3bce58726a01ff915d67512a1b722f553626dca614f394aa481d77f9525         application/vnd.docker.distribution.manifest.v2+json      sha256:cc7ea3bce58726a01ff915d67512a1b722f553626dca614f394aa481d77f9525 15.2 MiB  linux/amd64                                                                                           io.cri-containerd.image=managed 
registry.jujucharms.com/charm/dvbszzgs66b9bbmcs48joij6tx51m16cr36zp/knative-operator-webhook-image@sha256:3a026d989452e9036b92cee168e827b0390f927c75c853622b63b370ec8163d1 application/vnd.docker.distribution.manifest.v2+json      sha256:3a026d989452e9036b92cee168e827b0390f927c75c853622b63b370ec8163d1 13.5 MiB  linux/amd64                                                                                           io.cri-containerd.image=managed 

```
Execute the script:
```
$ bash tools/get-images.sh 
gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:dabaecec38860ca4c972e6821d5dc825549faf50c6feb8feb4c04802f2338b8a
gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:dabaecec38860ca4c972e6821d5dc825549faf50c6feb8feb4c04802f2338b8a
gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:c2994c2b6c2c7f38ad1b85c71789bf1753cc8979926423c83231e62258837cb9
gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:8319aa662b4912e8175018bd7cc90c63838562a27515197b803bdcd5634c7007
gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:98a2cc7fd62ee95e137116504e7166c32c65efef42c3d1454630780410abf943
gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:f66c41ad7a73f5d4f4bdfec4294d5459c477f09f3ce52934d1a215e32316b59b
gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:7368aaddf2be8d8784dc7195f5bc272ecfe49d429697f48de0ddc44f278167aa
gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:4305209ce498caf783f39c8f3e85dfa635ece6947033bf50b0b627983fd65953
gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:eb612b929eaa57ef1573a04035a8d06c9ed88fd56e741c56bd909f5f49e4d732
gcr.io/knative-releases/knative.dev/serving/cmd/default-domain@sha256:8ba8158fdcdb55862bf65282f3f8f5c79bdc8e6117576136a901e43f4a052d4a
gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:33ea8a657b974d7bf3d94c0b601a4fc287c1fb33430b3dda028a1a189e3d9526
gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:f4a9dfce9eec5272c90a19dbdf791fffc98bc5a6649ee85cb8a29bd5145635b1
gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:cbc452f35842cc8a78240642adc1ebb11a4c4d7c143c8277edb49012f6cfc5d3
gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:3ced549336c7ccf3bb2adf23a558eb55bd1aec7be17837062d21c749dfce8ce5
gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:e17bbdf951868359424cd0a0465da8ef44c66ba7111292444ce555c83e280f1a
gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:c5d3664780b394f6d3e546eb94c972965fbd9357da5e442c66455db7ca94124c
gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:c9c582f530155d22c01b43957ae0dba549b1cc903f77ec6cc1acb9ae9085be62
gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:2b484d982ef1a5d6ff93c46d3e45f51c2605c2e3ed766e20247d1727eb5ce918
gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:59b6a46d3b55a03507c76a3afe8a4ee5f1a38f1130fd3d65c9fe57fff583fa8d
gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:59431cf8337532edcd9a4bcd030591866cc867f13bee875d81757c960a53668d
gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:d0095787bc1687e2d8180b36a66997733a52f8c49c3e7751f067813e3fb54b66
gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.10.3
gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.10.3
otel/opentelemetry-collector:latest
```