### PR TITLE
knative-eventing: Add config option for component version

### DIFF
--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -2,6 +2,10 @@
 # See LICENSE file for licensing details.
 
 options:
+  version:
+    default: "1.8.0"
+    description: Version of knative-eventing component.
+    type: string
   namespace:
     default: ""
     description: The namespace to deploy Eventing to. This namespace cannot also contain another Knative Serving or Eventing instance. This configuration is required.

--- a/charms/knative-eventing/src/charm.py
+++ b/charms/knative-eventing/src/charm.py
@@ -130,6 +130,7 @@ class KnativeEventingCharm(CharmBase):
         context = {
             "app_name": self._app_name,
             "eventing_namespace": self.model.config["namespace"],
+            "eventing_version": self.model.config["version"],
             "custom_images": self._get_custom_images(),
         }
         if self._otel_collector_relation_data:

--- a/charms/knative-eventing/src/manifests/KnativeEventing.yaml.j2
+++ b/charms/knative-eventing/src/manifests/KnativeEventing.yaml.j2
@@ -4,6 +4,7 @@ metadata:
   name: {{ app_name }}
   namespace: {{ eventing_namespace }}
 spec:
+  version: {{ eventing_version }}
   config:
     _default:
       # This is not actually functional

--- a/charms/knative-eventing/tests/unit/test_charm.py
+++ b/charms/knative-eventing/tests/unit/test_charm.py
@@ -109,6 +109,7 @@ def test_context_changes(harness):
     context = {
         "app_name": harness.charm.app.name,
         "eventing_namespace": harness.model.config["namespace"],
+        "eventing_version": harness.model.config["version"],
         CUSTOM_IMAGE_CONFIG_NAME: DEFAULT_IMAGES,
     }
 


### PR DESCRIPTION
Add config option to specify the component version, similar to what we do for knative-serving.

Closes #136