### PR TITLE
knative-serving: Revert component's version to 1.8.0

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -46,9 +46,6 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.10.2"
+    default: "1.8.0"
     description: Version of knative-serving component.
     type: string
   namespace:


### PR DESCRIPTION
Revert knative-serving version to 1.8.0 since knative-operator cannot fetch manifests for versions >=1.10.x. More details in #147

#### How to test the PR
1. Deploy `knative-operator`
2. Deploy `knative-serving` (from the PR's branch always)
3. Check that 
    - there is no error or sth weird in `knativeserving` CR conditions (`kubectl get knativeserving -n knative-serving -o yaml`)
    - it creates deployments that do not error out 
    - it spins up pods for each of the deployments in `knative-serving` namespace that go in `Running` state