### PR TITLE
chore: bump knative-eventing 1.8.0 -> 1.10.1

### DIFF
--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.8.0"
+    default: "1.10.1"
     description: Version of knative-eventing component.
     type: string
   namespace:


### PR DESCRIPTION
Bump the default version from 1.8.0 to 1.10.1

Fixes #144