### PR TITLE
feat: make charms work on airgap environments

### DIFF
--- a/charms/knative-eventing/README.md
+++ b/charms/knative-eventing/README.md
@@ -11,3 +11,21 @@ juju deploy knative-eventing --config namespace="knative-eventing" --trust
 where:
 
 * namespace: The namespace knative-eventing resources will be deployed into (it cannot be deployed into the same namespace as knative-operator or knative-serving
+
+### Setting Custom Images for Knative Eventing
+
+Knative deploys with a set of preconfigured images.  These images, listed in the [upstream documentation](https://knative.dev/docs/install/operator/configuring-eventing-cr/#download-images-from-different-repositories-without-secrets), can be overridden using the charm config `custom_images`.
+
+For example:
+
+images_to_override.yaml
+```yaml
+eventing-controller/eventing-controller: docker.io/knative-images-repo1/eventing-controller:latest
+eventing-webhook/eventing-webhook: docker.io/knative-images-repo2/eventing-webhook:latest
+```
+
+```bash
+juju config knative-eventing custom_images=@./images_to_override.yaml
+```
+
+For convenience, the default value for `custom_images` in [config.yaml](./config.yaml) lists all images, where an empty string in the dictionary means the default will be used.

--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -6,3 +6,15 @@ options:
     default: ""
     description: The namespace to deploy Eventing to. This namespace cannot also contain another Knative Serving or Eventing instance. This configuration is required.
     type: string
+  custom_images:
+    default: |
+      eventing-controller/eventing-controller: ''
+      eventing-webhook/eventing-webhook: ''
+      imc-controller/controller: ''
+      imc-dispatcher/dispatcher: ''
+      broker-controller/eventing-controller: ''
+    description: >
+      YAML or JSON formatted input defining images to use in Knative Eventing.  Any image omitted or set to '' here will
+      use a default image.  For usage details, see 
+      https://github.com/canonical/knative-operators/blob/main/charms/knative-eventing/README.md#setting-custom-images-for-knative-eventing.
+    type: string

--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -2,6 +2,10 @@
 # See LICENSE file for licensing details.
 
 options:
+  version:
+    default: "1.8.0"
+    description: Version of knative-eventing component.
+    type: string
   namespace:
     default: ""
     description: The namespace to deploy Eventing to. This namespace cannot also contain another Knative Serving or Eventing instance. This configuration is required.

--- a/charms/knative-eventing/src/charm.py
+++ b/charms/knative-eventing/src/charm.py
@@ -11,6 +11,7 @@ import logging
 import traceback
 from pathlib import Path
 
+import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler as KRH  # noqa N813
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
@@ -19,9 +20,14 @@ from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 
+from image_management import parse_image_config, remove_empty_images, update_images
 from lightkube_custom_resources.operator import KnativeEventing_v1beta1  # noqa F401
 
 logger = logging.getLogger(__name__)
+
+
+CUSTOM_IMAGE_CONFIG_NAME = "custom_images"
+DEFAULT_IMAGES = {}
 
 
 class KnativeEventingCharm(CharmBase):
@@ -57,6 +63,26 @@ class KnativeEventingCharm(CharmBase):
             # let's use the compute_status() method to set (or not)
             # an active status
             self.unit.status = ActiveStatus()
+
+    def _get_custom_images(self):
+        """Parses custom_images from config and defaults, returning a dict of images."""
+        try:
+            default_images = remove_empty_images(DEFAULT_IMAGES)
+            custom_images = parse_image_config(self.model.config[CUSTOM_IMAGE_CONFIG_NAME])
+            custom_images = update_images(
+                default_images=default_images, custom_images=custom_images
+            )
+        except yaml.YAMLError as err:
+            logger.error(
+                f"Charm Blocked due to error parsing the `custom_images` config.  "
+                f"Caught error: {str(err)}"
+            )
+            raise ErrorWithStatus(
+                "Error parsing the `custom_images` config - fix `custom_images` to unblock.  "
+                "See logs for more details",
+                BlockedStatus,
+            )
+        return custom_images
 
     def _on_install(self, _):
         if not self.model.config["namespace"]:
@@ -104,6 +130,7 @@ class KnativeEventingCharm(CharmBase):
         context = {
             "app_name": self._app_name,
             "eventing_namespace": self.model.config["namespace"],
+            "custom_images": self._get_custom_images(),
         }
         if self._otel_collector_relation_data:
             context.update(self._otel_collector_relation_data)

--- a/charms/knative-eventing/src/charm.py
+++ b/charms/knative-eventing/src/charm.py
@@ -130,6 +130,7 @@ class KnativeEventingCharm(CharmBase):
         context = {
             "app_name": self._app_name,
             "eventing_namespace": self.model.config["namespace"],
+            "eventing_version": self.model.config["version"],
             "custom_images": self._get_custom_images(),
         }
         if self._otel_collector_relation_data:

--- a/charms/knative-eventing/src/image_management.py
+++ b/charms/knative-eventing/src/image_management.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+from typing import Dict
+
+import yaml
+
+
+def parse_image_config(image_config: str) -> Dict[str, str]:
+    """Parses config data for a dict of images, returning the parsed value as a dict.
+
+    This helper does not catch YAML parsing errors, leaving that up to the calling function.
+    Generally, this should be called inside a `try/except YAMLError` block.
+    """
+    images_from_config = yaml.safe_load(image_config)
+
+    if not images_from_config:
+        images_from_config = {}
+
+    images_from_config = remove_empty_images(images=images_from_config)
+
+    return images_from_config
+
+
+def remove_empty_images(images: Dict[str, str]):
+    """Removes any image with a value of an empty string, returning a new dict of the images."""
+    return {name: value for name, value in images.items() if value != ""}
+
+
+def update_images(default_images: Dict[str, str], custom_images: Dict[str, str]) -> Dict[str, str]:
+    """Returns a copy of default_images that is updated with overrides from custom_images."""
+    images = default_images.copy()
+    images.update(custom_images)
+    return images

--- a/charms/knative-eventing/src/manifests/KnativeEventing.yaml.j2
+++ b/charms/knative-eventing/src/manifests/KnativeEventing.yaml.j2
@@ -4,6 +4,7 @@ metadata:
   name: {{ app_name }}
   namespace: {{ eventing_namespace }}
 spec:
+  version: {{ eventing_version }}
   config:
     _default:
       # This is not actually functional

--- a/charms/knative-eventing/src/manifests/KnativeEventing.yaml.j2
+++ b/charms/knative-eventing/src/manifests/KnativeEventing.yaml.j2
@@ -13,3 +13,10 @@ spec:
       metrics.backend-destination: opencensus
       metrics.opencensus-address: {{ otel_collector_svc_name }}.{{ otel_collector_svc_namespace }}:{{ otel_collector_port }}
 {% endif %}
+{% if custom_images %}
+  registry:
+    override:
+      {% for container, image in custom_images.items() %}
+      {{ container }}: {{ image }}
+      {% endfor %}
+{% endif %}

--- a/charms/knative-eventing/tests/unit/test_charm.py
+++ b/charms/knative-eventing/tests/unit/test_charm.py
@@ -109,6 +109,7 @@ def test_context_changes(harness):
     context = {
         "app_name": harness.charm.app.name,
         "eventing_namespace": harness.model.config["namespace"],
+        "eventing_version": harness.model.config["version"],
         CUSTOM_IMAGE_CONFIG_NAME: DEFAULT_IMAGES,
     }
 

--- a/charms/knative-eventing/tests/unit/test_image_management.py
+++ b/charms/knative-eventing/tests/unit/test_image_management.py
@@ -1,0 +1,62 @@
+from contextlib import nullcontext
+
+import pytest
+import yaml
+
+from image_management import parse_image_config, update_images
+
+
+@pytest.mark.parametrize(
+    "image_config_str, expected_images_dict, context_raised",
+    [
+        (
+            # Test a basic case
+            yaml.dump({"key1": "value1", "key2": "value2"}),
+            {"key1": "value1", "key2": "value2"},
+            nullcontext(),
+        ),
+        (
+            # Test that we remove empty values from the dict
+            yaml.dump({"key1": "value1", "key2": ""}),
+            {"key1": "value1"},
+            nullcontext(),
+        ),
+        (
+            # Test empty string, which is converted to empty dict
+            "",
+            {},
+            nullcontext(),
+        ),
+        (
+            # Test invalid yaml
+            "{",
+            {},
+            pytest.raises(yaml.YAMLError),
+        ),
+    ],
+)
+def test_parse_image_config(image_config_str, expected_images_dict, context_raised):
+    # Arrange
+
+    # Act
+    with context_raised:
+        actual_images = parse_image_config(image_config_str)
+
+        # Assert
+        assert actual_images == expected_images_dict
+
+
+@pytest.mark.parametrize(
+    "default_images, custom_images, expected_images",
+    [
+        (
+            {"key1": "value1", "key2": "value2"},
+            {"key2": "value2b", "key3": "value3"},
+            {"key1": "value1", "key2": "value2b", "key3": "value3"},
+        )
+    ],
+)
+def test_update_images(default_images, custom_images, expected_images):
+    actual_images = update_images(default_images, custom_images)
+
+    assert actual_images == expected_images

--- a/charms/knative-serving/README.md
+++ b/charms/knative-serving/README.md
@@ -15,3 +15,21 @@ where:
 * namespace: The namespace knative-serving resources will be deployed into (it cannot be deployed into the same namespace as knative-operator or knative-eventing
 * istio.gateway.namespace: The namespace the Istio gateway is deployed to (generally, the model that Istio is deployed to).
 * istio.gateway.name: The name of the Istio gateway
+
+### Setting Custom Images for Knative Serving
+
+Knative deploys with a set of preconfigured images.  These images, listed in the [upstream documentation](https://knative.dev/docs/install/operator/configuring-serving-cr/#download-images-individually-without-secrets), can be overridden using the charm config `custom_images`.
+
+For example:
+
+images_to_override.yaml
+```yaml
+activator: 'my.repo/my-activator:latest'
+controller: 'my.repo/my-controller:v1.2.3'
+```
+
+```bash
+juju config knative-serving custom_images=@./images_to_override.yaml
+```
+
+For convenience, the default value for `custom_images` in [config.yaml](./config.yaml) lists all images, where an empty string in the dictionary means the default will be used.

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -22,3 +22,18 @@ options:
     default: ""
     description: (TEMP) The namespace where istio is deployed. It is usually the model name where istio (pilot and gateway) are deployed. This configuration is required.
     type: string
+  custom_images:
+    default: |
+      activator: ''
+      autoscaler: ''
+      controller: ''
+      webhook: ''
+      autoscaler-hpa: ''
+      net-istio-controller/controller: ''
+      net-istio-webhook/webhook: ''
+      queue-proxy: ''
+    description: >
+      YAML or JSON formatted input defining images to use in Knative Serving.  Any image omitted or set to '' here will
+      use a default image.  For usage details, see 
+      https://github.com/canonical/knative-operators/blob/main/charms/knative-serving/README.md#setting-custom-images-for-knative-serving.
+    type: string

--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -11,6 +11,7 @@ import logging
 import traceback
 from pathlib import Path
 
+import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler as KRH  # noqa N813
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
@@ -20,9 +21,14 @@ from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 
+from image_management import parse_image_config, remove_empty_images, update_images
 from lightkube_custom_resources.operator import KnativeServing_v1beta1  # noqa F401
 
 logger = logging.getLogger(__name__)
+
+
+CUSTOM_IMAGE_CONFIG_NAME = "custom_images"
+DEFAULT_IMAGES = {}
 
 
 class KnativeServingCharm(CharmBase):
@@ -68,6 +74,26 @@ class KnativeServingCharm(CharmBase):
             # let's use the compute_status() method to set (or not)
             # an active status
             self.unit.status = ActiveStatus()
+
+    def _get_custom_images(self):
+        """Parses custom_images from config and defaults, returning a dict of images."""
+        try:
+            default_images = remove_empty_images(DEFAULT_IMAGES)
+            custom_images = parse_image_config(self.model.config[CUSTOM_IMAGE_CONFIG_NAME])
+            custom_images = update_images(
+                default_images=default_images, custom_images=custom_images
+            )
+        except yaml.YAMLError as err:
+            logger.error(
+                f"Charm Blocked due to error parsing the `custom_images` config.  "
+                f"Caught error: {str(err)}"
+            )
+            raise ErrorWithStatus(
+                "Error parsing the `custom_images` config - fix `custom_images` to unblock.  "
+                "See logs for more details",
+                BlockedStatus,
+            )
+        return custom_images
 
     def _on_install(self, _):
         if not self.model.config["namespace"]:
@@ -142,6 +168,7 @@ class KnativeServingCharm(CharmBase):
             "gateway_namespace": self.model.config["istio.gateway.namespace"],
             "serving_namespace": self.model.config["namespace"],
             "serving_version": self.model.config["version"],
+            "custom_images": self._get_custom_images(),
         }
         if self._otel_collector_relation_data:
             context.update(self._otel_collector_relation_data)

--- a/charms/knative-serving/src/image_management.py
+++ b/charms/knative-serving/src/image_management.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+from typing import Dict
+
+import yaml
+
+
+def parse_image_config(image_config: str) -> Dict[str, str]:
+    """Parses config data for a dict of images, returning the parsed value as a dict.
+
+    This helper does not catch YAML parsing errors, leaving that up to the calling function.
+    Generally, this should be called inside a `try/except YAMLError` block.
+    """
+    images_from_config = yaml.safe_load(image_config)
+
+    if not images_from_config:
+        images_from_config = {}
+
+    images_from_config = remove_empty_images(images=images_from_config)
+
+    return images_from_config
+
+
+def remove_empty_images(images: Dict[str, str]) -> Dict[str, str]:
+    """Removes any image with a value of an empty string, returning a new dict of the images."""
+    return {name: value for name, value in images.items() if value != ""}
+
+
+def update_images(default_images: Dict[str, str], custom_images: Dict[str, str]) -> Dict[str, str]:
+    """Returns a copy of default_images that is updated with overrides from custom_images."""
+    images = default_images.copy()
+    images.update(custom_images)
+    return images

--- a/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
+++ b/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
@@ -27,3 +27,10 @@ spec:
       metrics.request-metrics-backend-destination: opencensus
       metrics.opencensus-address: {{ otel_collector_svc_name }}.{{ otel_collector_svc_namespace }}:{{ otel_collector_port }}
 {% endif %}
+{% if custom_images %}
+  registry:
+    override:
+      {% for container, image in custom_images.items() %}
+      {{ container }}: {{ image }}
+      {% endfor %}
+{% endif %}

--- a/charms/knative-serving/tests/unit/test_charm.py
+++ b/charms/knative-serving/tests/unit/test_charm.py
@@ -4,9 +4,13 @@ from contextlib import nullcontext as does_not_raise
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from charmed_kubeflow_chisme.lightkube.mocking import FakeApiError
 from lightkube import ApiError
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+
+from charm import CUSTOM_IMAGE_CONFIG_NAME, DEFAULT_IMAGES
 
 
 class _FakeResponse:
@@ -170,6 +174,7 @@ def test_context_changes(harness):
         "gateway_namespace": harness.model.config["istio.gateway.namespace"],
         "serving_namespace": harness.model.config["namespace"],
         "serving_version": harness.model.config["version"],
+        CUSTOM_IMAGE_CONFIG_NAME: DEFAULT_IMAGES,
     }
 
     assert harness.charm._context == context
@@ -184,6 +189,45 @@ def test_context_changes(harness):
     with does_not_raise():
         harness.update_relation_data(rel_id, "app", additional_context)
         assert harness.charm._context == context
+
+
+@pytest.mark.parametrize(
+    "custom_image_config, expected_custom_images",
+    [
+        (
+            yaml.dump({"name1": "image1", "name2": "image2"}),
+            {"name1": "image1", "name2": "image2"},
+        ),
+        (
+            yaml.dump({}),
+            {},
+        ),
+    ],
+)
+def test_custom_images_config_context(custom_image_config, expected_custom_images, harness):
+    """Asserts that the custom_images context is as expected.
+
+    Note: This test is trivial now, where custom_image_config always equals custom_images, but
+    once we've implemented rocks for this charm those will be used as the defaults and this test
+    will be more helpful.
+    """
+    harness.update_config({"custom_images": custom_image_config})
+    harness.begin()
+
+    actual_context = harness.charm._context
+    actual_custom_images = actual_context["custom_images"]
+
+    assert actual_custom_images == expected_custom_images
+
+
+def test_custom_images_config_context_with_incorrect_config(harness):
+    """Asserts that the custom_images context correctly raises on corrupted config input."""
+    harness.update_config({"custom_images": "{"})
+    harness.begin()
+
+    with pytest.raises(ErrorWithStatus) as err:
+        harness.charm._context
+        assert isinstance(err.status, BlockedStatus)
 
 
 @patch("charm.KRH")

--- a/charms/knative-serving/tests/unit/test_image_management.py
+++ b/charms/knative-serving/tests/unit/test_image_management.py
@@ -1,0 +1,62 @@
+from contextlib import nullcontext
+
+import pytest
+import yaml
+
+from image_management import parse_image_config, update_images
+
+
+@pytest.mark.parametrize(
+    "image_config_str, expected_images_dict, context_raised",
+    [
+        (
+            # Test a basic case
+            yaml.dump({"key1": "value1", "key2": "value2"}),
+            {"key1": "value1", "key2": "value2"},
+            nullcontext(),
+        ),
+        (
+            # Test that we remove empty values from the dict
+            yaml.dump({"key1": "value1", "key2": ""}),
+            {"key1": "value1"},
+            nullcontext(),
+        ),
+        (
+            # Test empty string, which is converted to empty dict
+            "",
+            {},
+            nullcontext(),
+        ),
+        (
+            # Test invalid yaml
+            "{",
+            {},
+            pytest.raises(yaml.YAMLError),
+        ),
+    ],
+)
+def test_parse_image_config(image_config_str, expected_images_dict, context_raised):
+    # Arrange
+
+    # Act
+    with context_raised:
+        actual_images = parse_image_config(image_config_str)
+
+        # Assert
+        assert actual_images == expected_images_dict
+
+
+@pytest.mark.parametrize(
+    "default_images, custom_images, expected_images",
+    [
+        (
+            {"key1": "value1", "key2": "value2"},
+            {"key2": "value2b", "key3": "value3"},
+            {"key1": "value1", "key2": "value2b", "key3": "value3"},
+        )
+    ],
+)
+def test_update_images(default_images, custom_images, expected_images):
+    actual_images = update_images(default_images, custom_images)
+
+    assert actual_images == expected_images

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -3,6 +3,7 @@ flake8
 # Pinning to <3.0 due to compatibility with the 2.9 controller version and 3.0 not being maintained anymore
 juju<3.0
 lightkube
+pytest-asyncio
 pytest-operator
 PyYAML
 tenacity

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 KSVC = create_namespaced_resource(
     group="serving.knative.dev", version="v1", kind="Service", plural="services"
 )
+KNATIVE_EVENTING_NAMESPACE = "knative-eventing"
 KNATIVE_SERVING_NAMESPACE = "knative-serving"
 KNATIVE_SERVING_SERVICE = "services.serving.knative.dev"
 KNATIVE_OPERATOR_METADATA = yaml.safe_load(
@@ -101,7 +102,7 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest):
     await ops_test.model.deploy(
         knative_charms["knative-eventing"],
         application_name="knative-eventing",
-        config={"namespace": "knative-eventing"},
+        config={"namespace": KNATIVE_EVENTING_NAMESPACE},
         trust=True,
     )
 
@@ -208,6 +209,49 @@ async def test_cloud_events_player_example(
     assert post_req.status_code == 202
     get_req = requests.get(f"{url}/messages", allow_redirects=False, verify=False)
     assert get_req.status_code == 200
+
+
+@pytest_asyncio.fixture
+async def restore_eventing_custom_image_settings(ops_test: OpsTest):
+    """Saves the current custom_image setting for eventing, restoring it after test completes."""
+    custom_image_config = (await ops_test.model.applications["knative-eventing"].get_config())[
+        "custom_images"
+    ]["value"]
+
+    yield
+    await ops_test.model.applications["knative-eventing"].set_config(
+        {"custom_images": custom_image_config}
+    )
+
+    await ops_test.model.wait_for_idle(
+        ["knative-eventing"],
+        status="active",
+        raise_on_blocked=False,
+        timeout=60 * 1,
+    )
+
+
+async def test_eventing_custom_image(ops_test: OpsTest, restore_eventing_custom_image_settings):
+    """Changes config to use a custom image for eventing-controller, then asserts it worked."""
+    fake_image = "not-a-real-image"
+
+    # Act
+    await ops_test.model.applications["knative-eventing"].set_config(
+        {"custom_images": f"eventing-controller/eventing-controller: {fake_image}"}
+    )
+    await ops_test.model.wait_for_idle(
+        ["knative-eventing"],
+        status="active",
+        raise_on_blocked=False,
+        timeout=60 * 1,
+    )
+
+    # Assert that the activator image is trying to use the custom image.
+    client = lightkube.Client()
+    activator_deployment = client.get(
+        Deployment, "eventing-controller", namespace=KNATIVE_EVENTING_NAMESPACE
+    )
+    assert activator_deployment.spec.template.spec.containers[0].image == fake_image
 
 
 @pytest_asyncio.fixture

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -7,11 +7,13 @@ from pathlib import Path
 
 import lightkube.codecs
 import pytest
+import pytest_asyncio
 import requests
 import yaml
 from lightkube import ApiError, Client
 from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
+from lightkube.resources.apps_v1 import Deployment
 from lightkube.resources.core_v1 import Service
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_delay, wait_fixed
@@ -21,6 +23,7 @@ log = logging.getLogger(__name__)
 KSVC = create_namespaced_resource(
     group="serving.knative.dev", version="v1", kind="Service", plural="services"
 )
+KNATIVE_SERVING_NAMESPACE = "knative-serving"
 KNATIVE_SERVING_SERVICE = "services.serving.knative.dev"
 KNATIVE_OPERATOR_METADATA = yaml.safe_load(
     Path("./charms/knative-operator/metadata.yaml").read_text()
@@ -88,7 +91,10 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest):
     await ops_test.model.deploy(
         knative_charms["knative-serving"],
         application_name="knative-serving",
-        config={"namespace": "knative-serving", "istio.gateway.namespace": ops_test.model_name},
+        config={
+            "namespace": KNATIVE_SERVING_NAMESPACE,
+            "istio.gateway.namespace": ops_test.model_name,
+        },
         trust=True,
     )
 
@@ -202,3 +208,44 @@ async def test_cloud_events_player_example(
     assert post_req.status_code == 202
     get_req = requests.get(f"{url}/messages", allow_redirects=False, verify=False)
     assert get_req.status_code == 200
+
+
+@pytest_asyncio.fixture
+async def restore_serving_custom_image_settings(ops_test: OpsTest):
+    """Saves the current custom_image setting for serving, restoring it after test completes."""
+    custom_image_config = (await ops_test.model.applications["knative-serving"].get_config())[
+        "custom_images"
+    ]["value"]
+
+    yield
+    await ops_test.model.applications["knative-serving"].set_config(
+        {"custom_images": custom_image_config}
+    )
+
+    await ops_test.model.wait_for_idle(
+        ["knative-serving"],
+        status="active",
+        raise_on_blocked=False,
+        timeout=60 * 1,
+    )
+
+
+async def test_serving_custom_image(ops_test: OpsTest, restore_serving_custom_image_settings):
+    """Changes config to use a custom image for the serving Activator, then asserts it worked."""
+    fake_image = "not-a-real-image"
+
+    # Act
+    await ops_test.model.applications["knative-serving"].set_config(
+        {"custom_images": f"activator: {fake_image}"}
+    )
+    await ops_test.model.wait_for_idle(
+        ["knative-serving"],
+        status="active",
+        raise_on_blocked=False,
+        timeout=60 * 1,
+    )
+
+    # Assert that the activator image is trying to use the custom image.
+    client = lightkube.Client()
+    activator_deployment = client.get(Deployment, "activator", namespace=KNATIVE_SERVING_NAMESPACE)
+    assert activator_deployment.spec.template.spec.containers[0].image == fake_image

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,31 +1,59 @@
 #!/bin/bash
 #
 # This script returns list of container images that are managed by this charm and/or its workload
-#
-# static list
-STATIC_IMAGE_LIST=(
-# manual addition based on https://github.com/canonical/knative-operators/issues/137
-gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:33ea8a657b974d7bf3d94c0b601a4fc287c1fb33430b3dda028a1a189e3d9526
-gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:f4a9dfce9eec5272c90a19dbdf791fffc98bc5a6649ee85cb8a29bd5145635b1
-gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:cbc452f35842cc8a78240642adc1ebb11a4c4d7c143c8277edb49012f6cfc5d3
-gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:3ced549336c7ccf3bb2adf23a558eb55bd1aec7be17837062d21c749dfce8ce5
-gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:e17bbdf951868359424cd0a0465da8ef44c66ba7111292444ce555c83e280f1a
-gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:c5d3664780b394f6d3e546eb94c972965fbd9357da5e442c66455db7ca94124c
-gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:c9c582f530155d22c01b43957ae0dba549b1cc903f77ec6cc1acb9ae9085be62
-gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:2b484d982ef1a5d6ff93c46d3e45f51c2605c2e3ed766e20247d1727eb5ce918
-gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:59b6a46d3b55a03507c76a3afe8a4ee5f1a38f1130fd3d65c9fe57fff583fa8d
-gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:59431cf8337532edcd9a4bcd030591866cc867f13bee875d81757c960a53668d
-gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:d0095787bc1687e2d8180b36a66997733a52f8c49c3e7751f067813e3fb54b66
-gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:c3bbf3a96920048869dcab8e133e00f59855670b8a0bbca3d72ced2f512eb5e1
-gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:7003443f0faabbaca12249aa16b73fa171bddf350abd826dd93b06f5080a146d
-gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:caae5e34b4cb311ed8551f2778cfca566a77a924a59b775bd516fa8b5e3c1d7f
-gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:38f9557f4d61ec79cc2cdbe76da8df6c6ae5f978a50a2847c22cc61aa240da95
-gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:a4ba0076df2efaca2eed561339e21b3a4ca9d90167befd31de882bff69639470
-gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:763d648bf1edee2b4471b0e211dbc53ba2d28f92e4dae28ccd39af7185ef2c96
-gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:bc13765ba4895c0fa318a065392d05d0adc0e20415c739e0aacb3f56140bf9ae
-)
-# dynamic list
 IMAGE_LIST=()
+IMAGE_LIST+=($(find . -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 IMAGE_LIST+=($(grep image charms/knative-operator/src/manifests/observability/collector.yaml.j2 | awk '{print $2}' | sort --unique))
-printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
-printf "%s\n" "${IMAGE_LIST[@]}"
+# obtain knative eventing version and corresponding knative release information
+KNATIVE_EVENTING_VERSION=$(yq -N '.options.version.default' ./charms/knative-eventing/config.yaml)
+KNATIVE_EVENTING_REPO_DOWNLOAD_URL=https://github.com/knative/eventing/releases/download/
+EVENTING_IMAGE_LIST=()
+wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSION}/eventing-core.yaml"
+EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./eventing-core.yaml))
+wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSION}/eventing.yaml"
+EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./eventing.yaml))
+wget -q "${KNATIVE_EVENTING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_EVENTING_VERSION}/eventing-post-install.yaml"
+EVENTING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./eventing-post-install.yaml))
+# obtain knative serving version and corresponding knative release information
+KNATIVE_SERVING_VERSION=$(yq -N '.options.version.default' ./charms/knative-serving/config.yaml)
+KNATIVE_SERVING_REPO_DOWNLOAD_URL=https://github.com/knative/serving/releases/download/
+SERVING_IMAGE_LIST=()
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-core.yaml"
+SERVING_IMAGE_LIST+=($(yq -N '.spec.image' ./serving-core.yaml))
+SERVING_IMAGE_LIST+=($(yq -N '.data.queue-sidecar-image' ./serving-core.yaml))
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-core.yaml))
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-hpa.yaml"
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-hpa.yaml))
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-default-domain.yaml"
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-default-domain.yaml))
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-storage-version-migration.yaml"
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-storage-version-migration.yaml))
+wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-post-install-jobs.yaml"
+SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-post-install-jobs.yaml))
+# obtain net istio images based on hardcoded version
+NET_ISTIO_VERSION="${KNATIVE_SERVING_VERSION}"
+# NOTE: for KNative Serving version 1.10.2 Net Istio version must be set to 1.11.0
+#       this need to be reviewed if KNative Serving version is changed
+if [ $KNATIVE_SERVING_VERSION == "1.10.2" ]; then
+  NET_ISTIO_VERSION="1.11.0"
+fi
+NET_ISTIO_REPO_DOWNLOAD_URL=https://github.com/knative-extensions/net-istio/releases/download/
+NET_ISTIO_IMAGE_LIST=()
+wget -q "${NET_ISTIO_REPO_DOWNLOAD_URL}knative-v${NET_ISTIO_VERSION}/net-istio.yaml"
+NET_ISTIO_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./net-istio.yaml))
+
+# remove nulls from arrays
+del_null="null"
+EVENTING_IMAGE_LIST=("${EVENTING_IMAGE_LIST[@]/$del_null}")
+SERVING_IMAGE_LIST=("${SERVING_IMAGE_LIST[@]/$del_null}")
+NET_ISTIO_IMAGE_LIST=("${NET_ISTIO_IMAGE_LIST[@]/$del_null}")
+IMAGE_LIST=("${IMAGE_LIST[@]/$del_null}")
+
+printf "%s\n" "${EVENTING_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
+printf "%s\n" "${SERVING_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
+printf "%s\n" "${NET_ISTIO_IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
+printf "%s\n" "${IMAGE_LIST[@]}" | sed -r '/^\s*$/d' | sort -u
+
+rm eventing-core.yaml eventing-post-install.yaml eventing.yaml net-istio.yaml \
+  serving-core.yaml serving-default-domain.yaml serving-hpa.yaml \
+  serving-post-install-jobs.yaml serving-storage-version-migration.yaml


### PR DESCRIPTION
This PR cherry picks:

* a44a964
* ba30ceb
* a22dd6e

so knative-operators can be deployed in an airgap environment. 

These changes are mirroring in `track/1.8` what we currently have in `main`.

Fixes #159 