### PR TITLE
feat: make otel-collector image configurable

### DIFF
--- a/charms/knative-operator/config.yaml
+++ b/charms/knative-operator/config.yaml
@@ -1,0 +1,7 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+options:
+  otel-collector-image:
+    default: "otel/opentelemetry-collector:latest"
+    type: string
+    description: Image to use by the otel collector Deployment.

--- a/charms/knative-operator/src/charm.py
+++ b/charms/knative-operator/src/charm.py
@@ -135,6 +135,7 @@ class KnativeOperatorCharm(CharmBase):
             "namespace": self._namespace,
             "name": self._app_name,
             "requestLogTemplate": REQUEST_LOG_TEMPLATE,
+            "otel_collector_image": self.config["otel-collector-image"],
         }
         return context
 

--- a/charms/knative-operator/src/manifests/observability/collector.yaml.j2
+++ b/charms/knative-operator/src/manifests/observability/collector.yaml.j2
@@ -46,7 +46,7 @@ spec:
       - name: collector
         args:
         - --config=/conf/collector.yaml
-        image: otel/opentelemetry-collector:latest
+        image: {{ otel_collector_image }}
         resources:
           requests:  # Note: these are suitable for a small instance, but may need to be increased for a large instance.
             memory: 100Mi


### PR DESCRIPTION
Pass the image to be used through a config option.

Fixes #161