### PR TITLE
Change manifests for v1.12.3

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.25-strict/stable
+          channel: 1.26-strict/stable
           juju-channel: 3.5/stable
           charmcraft-channel: latest/candidate
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
@@ -84,7 +84,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.25-strict/stable
+          channel: 1.26-strict/stable
           juju-channel: 3.5/stable
           charmcraft-channel: latest/candidate
 

--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.10.1"
+    default: "1.12.3"
     description: Version of knative-eventing component.
     type: string
   namespace:

--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -20,8 +20,8 @@ resources:
   knative-operator-image:
     type: oci-image
     description: OCI image for knative-operator
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.10.3
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.12.3
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.10.3
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.12.3

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -673,31 +673,6 @@ rules:
       - deployments
     verbs:
       - deletecollection
-  # Eventing TLS
-  - apiGroups:
-      - "cert-manager.io"
-    resources:
-      - certificates
-      - issuers
-      - clusterissuers
-    verbs:
-      - create
-      - delete
-      - update
-      - list
-      - get
-      - watch
-  - apiGroups:
-      - "trust.cert-manager.io"
-    resources:
-      - bundles
-    verbs:
-      - create
-      - delete
-      - update
-      - list
-      - get
-      - watch
 ---
 # Source: knative/operator/config/rbac/role_binding.yaml
 # TODO: Consider restriction of non-aggregated role to knativeservings namespaces.

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -31,9 +31,8 @@ kind: ClusterRole
 metadata:
   name: knative-serving-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-operator
+    app.kubernetes.io/name: knative-operator
 aggregationRule:
   clusterRoleSelectors:
     # This (along with escalate below) allows the Operator to pick up any
@@ -49,9 +48,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-operator-aggregated
   labels:
-    operator.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-operator
+    app.kubernetes.io/name: knative-operator
 aggregationRule:
   clusterRoleSelectors:
     # This (along with escalate below) allows the Operator to pick up any
@@ -67,9 +65,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-operator
+    app.kubernetes.io/name: knative-operator
 aggregationRule:
   clusterRoleSelectors:
     # This (along with escalate below) allows the Operator to pick up any
@@ -676,6 +673,31 @@ rules:
       - deployments
     verbs:
       - deletecollection
+  # Eventing TLS
+  - apiGroups:
+      - "cert-manager.io"
+    resources:
+      - certificates
+      - issuers
+      - clusterissuers
+    verbs:
+      - create
+      - delete
+      - update
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - bundles
+    verbs:
+      - create
+      - delete
+      - update
+      - list
+      - get
+      - watch
 ---
 # Source: knative/operator/config/rbac/role_binding.yaml
 # TODO: Consider restriction of non-aggregated role to knativeservings namespaces.
@@ -881,8 +903,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.10.3"
-    app.kubernetes.io/version: "1.10.3"
+    operator.knative.dev/release: "v1.12.3"
+    app.kubernetes.io/version: "1.12.3"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -898,8 +920,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.10.3"
-    app.kubernetes.io/version: "1.10.3"
+    operator.knative.dev/release: "v1.12.3"
+    app.kubernetes.io/version: "1.12.3"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -915,8 +937,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.10.3"
-    app.kubernetes.io/version: "1.10.3"
+    operator.knative.dev/release: "v1.12.3"
+    app.kubernetes.io/version: "1.12.3"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -932,8 +954,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.10.3"
-    app.kubernetes.io/version: "1.10.3"
+    operator.knative.dev/release: "v1.12.3"
+    app.kubernetes.io/version: "1.12.3"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
@@ -2308,8 +2308,14 @@ spec:
                         type: boolean
                       service-type:
                         type: string
+                      service-load-balancer-ip:
+                        type: string
                       bootstrap-configmap:
                         type: string
+                      http-port:
+                        type: integer
+                      https-port:
+                        type: integer
                     type: object
                 type: object
               security:

--- a/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
@@ -19,8 +19,8 @@ metadata:
   name: operator-webhook-certs
   namespace: {{ namespace }}
   labels:
-    app.kubernetes.io/component: webhook
-    operator.knative.dev/release: "v1.10.3"
-    app.kubernetes.io/version: "1.10.3"
-    app.kubernetes.io/part-of: knative-operator
+    app.kubernetes.io/component: operator-webhook
+    operator.knative.dev/release: "v1.12.3"
+    app.kubernetes.io/version: "v1.12.3"
+    app.kubernetes.io/name: knative-operator
 # The data is populated at install time.

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.10.2"
+    default: "1.12.3"
     description: Version of knative-serving component.
     type: string
   namespace:

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -267,6 +267,7 @@ async def test_eventing_custom_image(ops_test: OpsTest, restore_eventing_custom_
         status="active",
         raise_on_blocked=False,
         timeout=60 * 1,
+        idle_period=20
     )
 
     # Assert that the activator image is trying to use the custom image.

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -267,7 +267,7 @@ async def test_eventing_custom_image(ops_test: OpsTest, restore_eventing_custom_
         status="active",
         raise_on_blocked=False,
         timeout=60 * 1,
-        idle_period=20
+        idle_period=20,
     )
 
     # Assert that the activator image is trying to use the custom image.


### PR DESCRIPTION
closes: https://github.com/canonical/knative-operators/issues/181, https://github.com/canonical/knative-operators/issues/180, https://github.com/canonical/knative-operators/issues/179

Changes from https://github.com/knative/operator . Comparing tags `release-1.12` and `release-1.10` branches

Key changes: 
- image bumps 
- added new options to kourier object