### PR TITLE
fix: add missing images to custom images default for serving and eventing (#187)

### DIFF
--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -16,7 +16,10 @@ options:
       eventing-webhook/eventing-webhook: ''
       imc-controller/controller: ''
       imc-dispatcher/dispatcher: ''
-      broker-controller/eventing-controller: ''
+      mt-broker-controller/mt-broker-controller: ''
+      mt-broker-filter/filter: ''
+      mt-broker-ingress/ingress: ''
+      pingsource-mt-adapter/dispatcher: ''
     description: >
       YAML or JSON formatted input defining images to use in Knative Eventing.  Any image omitted or set to '' here will
       use a default image.  For usage details, see 

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -32,6 +32,9 @@ options:
       net-istio-controller/controller: ''
       net-istio-webhook/webhook: ''
       queue-proxy: ''
+      domain-mapping: ''
+      domainmapping-webhook: ''
+      migrate: ''
     description: >
       YAML or JSON formatted input defining images to use in Knative Serving.  Any image omitted or set to '' here will
       use a default image.  For usage details, see 


### PR DESCRIPTION
port-forwards #187 to `main`