### PR TITLE
chore: update manifests

### DIFF
--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.12.6"
+    default: "1.12.4"
     description: Version of knative-eventing component.
     type: string
   namespace:

--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.12.3"
+    default: "1.12.6"
     description: Version of knative-eventing component.
     type: string
   namespace:

--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -24,8 +24,8 @@ resources:
   knative-operator-image:
     type: oci-image
     description: OCI image for knative-operator
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.12.3
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.12.4
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.12.3
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.12.4

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -1,3 +1,4 @@
+# Source: knative/operator/config/rbac/clusterrole_aggregated.yaml
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Source: knative/operator/config/rbac/clusterrole_aggregated.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -878,8 +878,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.12.3"
-    app.kubernetes.io/version: "1.12.3"
+    operator.knative.dev/release: "v1.12.4"
+    app.kubernetes.io/version: "1.12.4"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -895,8 +895,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.12.3"
-    app.kubernetes.io/version: "1.12.3"
+    operator.knative.dev/release: "v1.12.4"
+    app.kubernetes.io/version: "1.12.4"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -912,8 +912,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.12.3"
-    app.kubernetes.io/version: "1.12.3"
+    operator.knative.dev/release: "v1.12.4"
+    app.kubernetes.io/version: "1.12.4"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -929,8 +929,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.12.3"
-    app.kubernetes.io/version: "1.12.3"
+    operator.knative.dev/release: "v1.12.4"
+    app.kubernetes.io/version: "1.12.4"
     app.kubernetes.io/part-of: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
@@ -20,7 +20,7 @@ metadata:
   namespace: {{ namespace }}
   labels:
     app.kubernetes.io/component: operator-webhook
-    operator.knative.dev/release: "v1.12.3"
-    app.kubernetes.io/version: "v1.12.3"
+    operator.knative.dev/release: "v1.12.4"
+    app.kubernetes.io/version: "v1.12.4"
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.12.3"
+    default: "1.12.4"
     description: Version of knative-serving component.
     type: string
   namespace:


### PR DESCRIPTION
Closes #195 

This PR updates the manifest files of `knative-eventing`, `knative-serving`, `knative-operator`. No major changes were made.