### PR TITLE
build: add rust toolchain and other build packages

### DIFF
--- a/charms/knative-operator/charmcraft.yaml
+++ b/charms/knative-operator/charmcraft.yaml
@@ -11,3 +11,4 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]


### PR DESCRIPTION
Adding the rust toolchain and other dependencies to avoid issues at build time.

Part of canonical/bundle-kubeflow#989