### PR TITLE
(cherry-pick to track/1.10) fix: configure proxy env vars in serving

### DIFF
--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -45,3 +45,15 @@ options:
     description: >
       Image to use for the `queue-proxy` sidecar container in a Knative Service workload Pod.
     type: string
+  http-proxy:
+    default: ""
+    description: The value of HTTP_PROXY environment variable in the serving controller.
+    type: string
+  https-proxy:
+    default: ""
+    description: The value of HTTPS_PROXY environment variable in the serving controller.
+    type: string  
+  no-proxy:
+    default: ""
+    description: The value of NO_PROXY environment variable in the serving controller.
+    type: string

--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -169,6 +169,9 @@ class KnativeServingCharm(CharmBase):
             "serving_namespace": self.model.config["namespace"],
             "serving_version": self.model.config["version"],
             "custom_images": self._get_custom_images(),
+            "http_proxy": self.model.config["http-proxy"],
+            "https_proxy": self.model.config["https-proxy"],
+            "no_proxy": self.model.config["no-proxy"],
         }
         if self._otel_collector_relation_data:
             context.update(self._otel_collector_relation_data)

--- a/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
+++ b/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
@@ -38,3 +38,22 @@ spec:
       {{ container }}: {{ image }}
       {% endfor %}
 {% endif %}
+{% if http_proxy or https_proxy or no_proxy %}
+  workloads:
+  - name: controller
+    env:
+    - container: controller
+      envVars:
+    {% if http_proxy %}
+      - name: HTTP_PROXY
+        value: {{ http_proxy }}
+    {% endif %}
+    {% if https_proxy %}
+      - name: HTTPS_PROXY
+        value: {{ https_proxy }}
+    {% endif %}
+    {% if no_proxy %}
+      - name: NO_PROXY
+        value: {{ no_proxy }}
+    {% endif %}
+{% endif %}

--- a/charms/knative-serving/tests/unit/test_charm.py
+++ b/charms/knative-serving/tests/unit/test_charm.py
@@ -164,6 +164,9 @@ def test_context_changes(harness):
             "namespace": "knative-serving",
             "istio.gateway.name": "knative-gateway",
             "istio.gateway.namespace": "istio-namespace",
+            "http-proxy": "my_http_proxy",
+            "https-proxy": "my_https_proxy",
+            "no-proxy": "my_no_proxy",
         }
     )
     harness.begin()
@@ -174,6 +177,9 @@ def test_context_changes(harness):
         "gateway_namespace": harness.model.config["istio.gateway.namespace"],
         "serving_namespace": harness.model.config["namespace"],
         "serving_version": harness.model.config["version"],
+        "http_proxy": harness.model.config["http-proxy"],
+        "https_proxy": harness.model.config["https-proxy"],
+        "no_proxy": harness.model.config["no-proxy"],
         CUSTOM_IMAGE_CONFIG_NAME: DEFAULT_IMAGES,
     }
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -363,3 +363,52 @@ async def test_queue_sidecar_image_config(
 
     # Assert that the Knative Service is trying to use the custom image.
     assert cloudevents_deployment.spec.template.spec.containers[1].image == fake_image
+
+
+async def test_serving_proxy_config(ops_test: OpsTest):
+    """
+    Changes `http-proxy`, `https-proxy` and `no-proxy` configs and checks that the Knative Serving
+    controller container is using the values from configs as environment variables.
+    """
+
+    # Act
+    test_http_proxy = "my_http_proxy"
+    test_https_proxy = "my_https_proxy"
+    test_no_proxy = "no_proxy"
+
+    await ops_test.model.applications["knative-serving"].set_config(
+        {"http-proxy": test_http_proxy, "https-proxy": test_https_proxy, "no-proxy": test_no_proxy}
+    )
+
+    await ops_test.model.wait_for_idle(
+        ["knative-serving"],
+        status="active",
+        raise_on_blocked=False,
+        timeout=60 * 1,
+    )
+
+    client = Client()
+
+    # Get Knative Serving controller Deployment
+    controller_deployment = client.get(
+        Deployment, "controller", namespace=KNATIVE_SERVING_NAMESPACE
+    )
+
+    # Get Knative Serving controller environment variables
+    serving_controller_env_vars = controller_deployment.spec.template.spec.containers[0].env
+
+    http_proxy_env = https_proxy_env = no_proxy_env = None
+
+    # Get proxy environment variables from all Knative Serving controller env vars
+    for env_var in serving_controller_env_vars:
+        if env_var.name == "HTTP_PROXY":
+            http_proxy_env = env_var.value
+        elif env_var.name == "HTTPS_PROXY":
+            https_proxy_env = env_var.value
+        elif env_var.name == "NO_PROXY":
+            no_proxy_env = env_var.value
+
+    # Assert Deployment spec contains correct proxy environment variables
+    assert http_proxy_env == test_http_proxy
+    assert https_proxy_env == test_https_proxy
+    assert no_proxy_env == test_no_proxy


### PR DESCRIPTION
backports #208 to `track/1.10`

## Testing the upgrade
1. Deploy the following bundle:
```
bundle: kubernetes
name: kubeflow
docs: https://discourse.charmhub.io/t/3749
applications:
  istio-ingressgateway:
    charm: istio-gateway
    channel: 1.17/stable
    scale: 1
    trust: true
    _github_repo_name: istio-operators
    _github_repo_branch: track/1.17
    options:
      kind: ingress
  istio-pilot:
    charm: istio-pilot
    channel: 1.17/stable
    scale: 1
    trust: true
    _github_repo_name: istio-operators
    _github_repo_branch: track/1.17
    options:
      default-gateway: kubeflow-gateway
  knative-eventing:
    charm: knative-eventing
    channel: 1.10/stable
    scale: 1
    trust: true
    options:
      namespace: knative-eventing
    _github_repo_name: knative-operators
    _github_repo_branch: track/1.10
  knative-operator:
    charm: knative-operator
    channel: 1.10/stable
    scale: 1
    trust: true
    _github_repo_name: knative-operators
    _github_repo_branch: track/1.10
  knative-serving:
    charm: knative-serving
    channel: 1.10/stable
    scale: 1
    trust: true
    options:
      namespace: knative-serving
      istio.gateway.namespace: kubeflow
      istio.gateway.name: kubeflow-gateway
    _github_repo_name: knative-operators
    _github_repo_branch: track/1.10
  kserve-controller:
    charm: kserve-controller
    channel: 0.11/stable
    scale: 1
    trust: true
    _github_repo_name: kserve-operators
    _github_repo_branch: track/0.11
relations:
  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
  - [kserve-controller:ingress-gateway, istio-pilot:gateway-info]
  - [kserve-controller:local-gateway, knative-serving:local-gateway]
```
2. Create a namespace to test with
```
kubectl create namespace testing
```
3. Apply KSVC example `cloudevents-player` to `testing` namespace:
```
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: cloudevents-player
spec:
  template:
    metadata:
      annotations:
        autoscaling.knative.dev/min-scale: "1"
    spec:
      containers:
        - image: ruromero/cloudevents-player:latest
          env:
            - name: BROKER_URL
              value: http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker
```
4. Check KSVC is `Ready`
```
kubectl get ksvc -n testing
NAME                        URL                                                            LATESTCREATED                     LATESTREADY                       READY   REASON
cloudevents-player          http://cloudevents-player.testing.10.64.140.43.nip.io          cloudevents-player-00001          cloudevents-player-00001          True    
```
5. Refresh `knative-serving` to the charm from this PR
```
juju refresh knative-serving --channel=1.10/edge/pr-217
```
### After the upgrade
* charm went to active after refresh
```
juju status | grep knative-serving
knative-serving                active      1  knative-serving    1.10/edge/pr-217   479  10.152.183.166  no       
knative-serving/0*       active    idle   10.1.199.253         
```
* ksvc created before upgrade is unaffected
```
kubectl get ksvc -n testing
NAME                        URL                                                            LATESTCREATED                     LATESTREADY                       READY   REASON
cloudevents-player          http://cloudevents-player.testing.10.64.140.43.nip.io          cloudevents-player-00001          cloudevents-player-00001          True    
```
* check the new charm configs for proxy exist
```
juju config knative-serving

application: knative-serving
application-config: 
...
charm: knative-serving
settings: 
...
  http-proxy: 
    default: ""
    description: The value of HTTP_PROXY environment variable in the serving controller.
    source: default
    type: string
    value: ""
  https-proxy: 
    default: ""
    description: The value of HTTPS_PROXY environment variable in the serving controller.
    source: default
    type: string
    value: ""
...
  no-proxy: 
    default: ""
    description: The value of NO_PROXY environment variable in the serving controller.
    source: default
    type: string
    value: ""
```
* Set the new proxy configs and check it takes effect in `KnativeServing` CR
```
juju config knative-serving http-proxy="test-http-proxy" https-proxy="test-https-proxy" no-proxy="test-no-proxy"
```
Get `KnativeServing`:
```
kubectl get KnativeServing -n knative-serving knative-serving -oyaml

apiVersion: operator.knative.dev/v1beta1
kind: KnativeServing
metadata:
  creationTimestamp: "2024-08-19T14:58:57Z"
  finalizers:
  - knativeservings.operator.knative.dev
  generation: 2
  name: knative-serving
  namespace: knative-serving
  resourceVersion: "622016"
  uid: 38cc3bd0-cd5e-4f20-a7bf-16cca47bae69
spec:
  config:
    domain:
      10.64.140.43.nip.io: ""
    istio:
      gateway.kubeflow.kubeflow-gateway: some-workload.knative-operator.svc.cluster.local
      local-gateway.knative-serving.knative-local-gateway: knative-local-gateway.kubeflow.svc.cluster.local
  version: 1.10.2
  workloads:
  - env:
    - container: controller
      envVars:
      - name: HTTP_PROXY
        value: test-http-proxy
      - name: HTTPS_PROXY
        value: test-https-proxy
      - name: NO_PROXY
        value: test-no-proxy
    name: controller
status:
  conditions:
  - lastTransitionTime: "2024-08-19T14:59:16Z"
    status: "True"
    type: DependenciesInstalled
  - lastTransitionTime: "2024-08-19T14:59:33Z"
    status: "True"
    type: DeploymentsAvailable
  - lastTransitionTime: "2024-08-19T14:59:16Z"
    status: "True"
    type: InstallSucceeded
  - lastTransitionTime: "2024-08-19T14:59:33Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2024-08-19T14:58:59Z"
    status: "True"
    type: VersionMigrationEligible
  manifests:
  - /var/run/ko/knative-serving/1.10.2
  - /var/run/ko/ingress/1.10/istio
  observedGeneration: 2
  version: 1.10.2
```