### PR TITLE
scripts: Fix net-istio version for 1.9 scanning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The script also needs to gather images for `net-istio`, that has it's own releas
 **Process:**
 1. Confirm the Knative Serving version
 2. Deduce the `net-istio` that should be used
-  * If you update based on a Kubeflow release, then you can deduce this from [upstream Kubeflow manifests](https://github.com/kubeflow/manifests/blob/v1.9-branch/common/knative/README.md?plain=1#L8) (make sure to checkout to correct release branch). Note that in the Kubeflow's README this will be refered as `Knative ingress controller for Istio`
+  * If you update based on a Kubeflow release, then you can deduce this from [upstream Kubeflow manifests](https://github.com/kubeflow/manifests/blob/v1.9-branch/common/knative/README.md?plain=1#L8) (make sure to checkout to correct release branch). Note that in the Kubeflow's README this will be referred as `Knative ingress controller for Istio`
   * If you update to an arbitrary Knative Serving version, then check the branches of [`net-istio`](https://github.com/knative-extensions/net-istio/tags) and pick the closest one to your Knative Serving release
 3. Update the `tools/get-images.sh` script to use the selected version of `net-istio`
   * If the `net-istio` tag is not 1-1 with the Serving version then hardcode the version of `net-istio` in the script

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The script also needs to gather images for `net-istio`, that has it's own releas
 **Process:**
 1. Confirm the Knative Serving version
 2. Deduce the `net-istio` that should be used
-  * If you update based on a Kubeflow release, then you can deduce this from [upstream Kubeflow manifests](https://github.com/kubeflow/manifests/blob/v1.9-branch/common/knative/README.md?plain=1#L8) (make sure to checkout to correct release branch)
+  * If you update based on a Kubeflow release, then you can deduce this from [upstream Kubeflow manifests](https://github.com/kubeflow/manifests/blob/v1.9-branch/common/knative/README.md?plain=1#L8) (make sure to checkout to correct release branch). Note that in the Kubeflow's README this will be refered as `Knative ingress controller for Istio`
   * If you update to an arbitrary Knative Serving version, then check the branches of [`net-istio`](https://github.com/knative-extensions/net-istio/tags) and pick the closest one to your Knative Serving release
 3. Update the `tools/get-images.sh` script to use the selected version of `net-istio`
   * If the `net-istio` tag is not 1-1 with the Serving version then hardcode the version of `net-istio` in the script

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ https://github.com/canonical/knative-operators/issues/220
 The script also needs to gather images for `net-istio`, that has it's own release cadance (although almost 1-1 with Knative Serving, but sometimes tags for Serving might not exist for `net-istio`).
 
 **Process:**
-1. Confirm the Knative Serving version you want to update `net-istio` for
+1. Confirm the Knative Serving version
 2. Deduce the `net-istio` that should be used
   * If you update based on a Kubeflow release, then you can deduce this from [upstream Kubeflow manifests](https://github.com/kubeflow/manifests/blob/v1.9-branch/common/knative/README.md?plain=1#L8) (make sure to checkout to correct release branch)
   * If you update to an arbitrary Knative Serving version, then check the branches of [`net-istio`](https://github.com/knative-extensions/net-istio/tags) and pick the closest one to your Knative Serving release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+## Update image gathering scripts
+
+For every release, we'll need to update the image gather scripts for fetching the images used by Knative Charms.
+
+To get an overview of how the script works please read https://github.com/canonical/knative-operators/issues/142
+The script has a limitation on how it's deducing images from upstream manifests, which is tracked in
+https://github.com/canonical/knative-operators/issues/220
+
+The script also needs to gather images for `net-istio`, that has it's own release cadance (although almost 1-1 with Knative Serving, but sometimes tags for Serving might not exist for `net-istio`).
+
+**Process:**
+1. Confirm the Knative Serving version you want to update `net-istio` for
+2. Deduce the `net-istio` that should be used
+  * If you update based on a Kubeflow release, then you can deduce this from [upstream Kubeflow manifests](https://github.com/kubeflow/manifests/blob/v1.9-branch/common/knative/README.md?plain=1#L8) (make sure to checkout to correct release branch)
+  * If you update to an arbitrary Knative Serving version, then check the branches of [`net-istio`](https://github.com/knative-extensions/net-istio/tags) and pick the closest one to your Knative Serving release
+3. Update the `tools/get-images.sh` script to use the selected version of `net-istio`
+  * If the `net-istio` tag is not 1-1 with the Serving version then hardcode the version of `net-istio` in the script

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -32,20 +32,10 @@ wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION
 SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-storage-version-migration.yaml))
 wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-post-install-jobs.yaml"
 SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-post-install-jobs.yaml))
-# obtain net istio images based on hardcoded version
-NET_ISTIO_VERSION="${KNATIVE_SERVING_VERSION}"
-# NOTE: for KNative Serving version 1.10.2 Net Istio version must be set to 1.11.0
-#       this need to be reviewed if KNative Serving version is changed
-if [ $KNATIVE_SERVING_VERSION == "1.10.2" ]; then
-  NET_ISTIO_VERSION="1.11.0"
-fi
 
 # For Serving 1.12.4 (CKF 1.9) we have to use 1.12.3 for net-istio
 # https://github.com/kubeflow/manifests/pull/2709
-if [ $KNATIVE_SERVING_VERSION == "1.12.4" ]; then
-  NET_ISTIO_VERSION="1.12.3"
-fi
-
+NET_ISTIO_VERSION="1.12.3"
 NET_ISTIO_REPO_DOWNLOAD_URL=https://github.com/knative-extensions/net-istio/releases/download/
 NET_ISTIO_IMAGE_LIST=()
 wget -q "${NET_ISTIO_REPO_DOWNLOAD_URL}knative-v${NET_ISTIO_VERSION}/net-istio.yaml"

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # This script returns list of container images that are managed by this charm and/or its workload
+set -xe
 
 IMAGE_LIST=()
 IMAGE_LIST+=($(find . -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
@@ -38,6 +39,13 @@ NET_ISTIO_VERSION="${KNATIVE_SERVING_VERSION}"
 if [ $KNATIVE_SERVING_VERSION == "1.10.2" ]; then
   NET_ISTIO_VERSION="1.11.0"
 fi
+
+# For Serving 1.12.4 (CKF 1.9) we have to use 1.12.3 for net-istio
+# https://github.com/kubeflow/manifests/pull/2709
+if [ $KNATIVE_SERVING_VERSION == "1.12.4" ]; then
+  NET_ISTIO_VERSION="1.12.3"
+fi
+
 NET_ISTIO_REPO_DOWNLOAD_URL=https://github.com/knative-extensions/net-istio/releases/download/
 NET_ISTIO_IMAGE_LIST=()
 wget -q "${NET_ISTIO_REPO_DOWNLOAD_URL}knative-v${NET_ISTIO_VERSION}/net-istio.yaml"


### PR DESCRIPTION
Closes https://github.com/canonical/knative-operators/issues/219

The PR hardcodes the version of net-istio to be used for the 1.12.4 version of Knative Service (used in CKF 1.9), similarly to how we handled it for CKF 1.8.

To verify:
```bash
# should contain net-istio
# should not have an error when gathering the images
./tools/get-images.sh | less
```