### PR TITLE
feat: Backport terraform modules for knative-{eventing,operator,serving} from #227

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -38,6 +38,23 @@ jobs:
       - run: sudo apt update && sudo apt install tox
       - run: tox -e ${{ matrix.charm }}-unit
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    strategy:
+      fail-fast: false
+      matrix:
+        charm: [operator, serving, eventing]
+    with:
+      charm-path: ./charms/knative-${{ matrix.charm }}
+      # Skipping the Terraform apply check as knative-eventing and knative-serving
+      # go to Error when knative-operator is not deployed, instead of the expected
+      # Blocked or Active. This is currently a limitation of the Terraform re-usable
+      # workflows in canonical/charmed-kubeflow-workflows
+      # See https://github.com/canonical/charmed-kubeflow-workflows/issues/65
+      # See https://github.com/canonical/knative-operators/issues/156
+      apply: false
+
   integration-charm-deployment:
     name: Integration Test
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+.terraform*
+*.tfstate*

--- a/charms/knative-eventing/terraform/README.md
+++ b/charms/knative-eventing/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for knative-eventing
+
+This is a Terraform module facilitating the deployment of the knative-eventing charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "knative-eventing" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "knative-eventing" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/knative-eventing/terraform/main.tf
+++ b/charms/knative-eventing/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "knative_eventing" {
+  charm {
+    name     = "knative-eventing"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/knative-eventing/terraform/outputs.tf
+++ b/charms/knative-eventing/terraform/outputs.tf
@@ -1,0 +1,13 @@
+output "app_name" {
+  value = juju_application.knative_eventing.name
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    otel_collector = "otel-collector"
+  }
+}

--- a/charms/knative-eventing/terraform/variables.tf
+++ b/charms/knative-eventing/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "knative-eventing"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/knative-eventing/terraform/variables.tf
+++ b/charms/knative-eventing/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "1.12/stable"
 }
 
 variable "config" {

--- a/charms/knative-eventing/terraform/versions.tf
+++ b/charms/knative-eventing/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/knative-eventing/tox.ini
+++ b/charms/knative-eventing/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/knative-operator/terraform/README.md
+++ b/charms/knative-operator/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for knative-operator
+
+This is a Terraform module facilitating the deployment of the knative-operator charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "knative-operator" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "knative-operator" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/knative-operator/terraform/main.tf
+++ b/charms/knative-operator/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "knative_operator" {
+  charm {
+    name     = "knative-operator"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/knative-operator/terraform/outputs.tf
+++ b/charms/knative-operator/terraform/outputs.tf
@@ -1,0 +1,16 @@
+output "app_name" {
+  value = juju_application.knative_operator.name
+}
+
+output "provides" {
+  value = {
+    otel_collector   = "otel-collector"
+    metrics_endpoint = "metrics-endpoint"
+  }
+}
+
+output "requires" {
+  value = {
+    logging = "logging"
+  }
+}

--- a/charms/knative-operator/terraform/variables.tf
+++ b/charms/knative-operator/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "knative-operator"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/knative-operator/terraform/variables.tf
+++ b/charms/knative-operator/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "1.12/stable"
 }
 
 variable "config" {

--- a/charms/knative-operator/terraform/versions.tf
+++ b/charms/knative-operator/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/knative-operator/tox.ini
+++ b/charms/knative-operator/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/knative-serving/terraform/README.md
+++ b/charms/knative-serving/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for knative-serving
+
+This is a Terraform module facilitating the deployment of the knative-serving charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "knative-serving" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "knative-serving" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/knative-serving/terraform/main.tf
+++ b/charms/knative-serving/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "knative_serving" {
+  charm {
+    name     = "knative-serving"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/knative-serving/terraform/outputs.tf
+++ b/charms/knative-serving/terraform/outputs.tf
@@ -1,0 +1,16 @@
+output "app_name" {
+  value = juju_application.knative_serving.name
+}
+
+output "provides" {
+  value = {
+    ingress_gateway = "ingress-gateway",
+    local_gateway   = "local-gateway"
+  }
+}
+
+output "requires" {
+  value = {
+    otel_collector = "otel-collector"
+  }
+}

--- a/charms/knative-serving/terraform/variables.tf
+++ b/charms/knative-serving/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "1.12/stable"
 }
 
 variable "config" {

--- a/charms/knative-serving/terraform/variables.tf
+++ b/charms/knative-serving/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "knative-serving"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/knative-serving/terraform/versions.tf
+++ b/charms/knative-serving/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/knative-serving/tox.ini
+++ b/charms/knative-serving/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
Create a `terraform/` directory for each of the charms to host their individual Terraform modules. It follows the structure proposed in [this spec](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit) and it is based on what was done in canonical/argo-operators#198.

Closes #224 
Closes #225 
Closes #226 