### PR TITLE
feat: integrate `knative-operator` rock

### DIFF
--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -24,7 +24,7 @@ resources:
   knative-operator-image:
     type: oci-image
     description: OCI image for knative-operator
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.12.4
+    upstream-source: charmedkubeflow/knative-operator:1.12.4-3f2a424
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component


### PR DESCRIPTION
Closes https://github.com/canonical/knative-operators/issues/245

Integrates the `knative-operator` Rock built from [this On Push CI run](https://github.com/canonical/knative-rocks/actions/runs/11929145009/job/33247869792), introduced in PR https://github.com/canonical/knative-rocks/pull/6.