### PR TITLE
Integrate `net-istio-webhook` rock

### DIFF
--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -30,7 +30,7 @@ options:
       webhook: ''
       autoscaler-hpa: ''
       net-istio-controller/controller: ''
-      net-istio-webhook/webhook: 'charmedkubeflow/net-istio-webhook:1.12.3-9e441a2'
+      net-istio-webhook/webhook: ''
       queue-proxy: ''
       domain-mapping: ''
       domainmapping-webhook: ''

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -30,7 +30,7 @@ options:
       webhook: ''
       autoscaler-hpa: ''
       net-istio-controller/controller: ''
-      net-istio-webhook/webhook: ''
+      net-istio-webhook/webhook: 'charmedkubeflow/net-istio-webhook:1.12.3-9e441a2'
       queue-proxy: ''
       domain-mapping: ''
       domainmapping-webhook: ''

--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 CUSTOM_IMAGE_CONFIG_NAME = "custom_images"
-DEFAULT_IMAGES = {"net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.12.3-9e441a2"}
+DEFAULT_IMAGES = {"net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.12.3-b455143"}
 
 
 class KnativeServingCharm(CharmBase):

--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 CUSTOM_IMAGE_CONFIG_NAME = "custom_images"
-DEFAULT_IMAGES = {}
+DEFAULT_IMAGES = {"net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.12.3-9e441a2"}
 
 
 class KnativeServingCharm(CharmBase):

--- a/charms/knative-serving/tests/unit/test_charm.py
+++ b/charms/knative-serving/tests/unit/test_charm.py
@@ -204,11 +204,11 @@ def test_context_changes(harness):
     [
         (
             yaml.dump({"name1": "image1", "name2": "image2"}),
-            {"name1": "image1", "name2": "image2"},
+            {**{"name1": "image1", "name2": "image2"}, **DEFAULT_IMAGES}
         ),
         (
             yaml.dump({}),
-            {},
+            DEFAULT_IMAGES,
         ),
     ],
 )

--- a/charms/knative-serving/tests/unit/test_charm.py
+++ b/charms/knative-serving/tests/unit/test_charm.py
@@ -204,7 +204,7 @@ def test_context_changes(harness):
     [
         (
             yaml.dump({"name1": "image1", "name2": "image2"}),
-            {**{"name1": "image1", "name2": "image2"}, **DEFAULT_IMAGES}
+            {**{"name1": "image1", "name2": "image2"}, **DEFAULT_IMAGES},
         ),
         (
             yaml.dump({}),


### PR DESCRIPTION
Closes: https://github.com/canonical/knative-operators/issues/241

As described in the issue we decided to change the value in `DEFAULT_IMAGES` for now.

If you want to run a simple manual test to be 100% sure everything is ok you can run bundle integration tests locally and then check the pods in serving namesapce: 

```
tox -e integration -- --model kubeflow --keep-models -vv -s
kubectl get po -n knative-serving

NAME                                                     READY   STATUS      RESTARTS   AGE
activator-76db578547-dpbfd                               1/1     Running     0          12s
autoscaler-57c4f8d4dd-zclxf                              1/1     Running     0          12s
autoscaler-hpa-d9f489c5f-tb9lg                           1/1     Running     0          10s
controller-59886d5596-vvm9g                              1/1     Running     0          11s
net-istio-controller-65b76fb5ff-647gz                    1/1     Running     0          8s
net-istio-webhook-698576f4f9-d6dzb                       1/1     Running     0          8s
storage-version-migration-serving-serving-1.12.4-6298b   0/1     Completed   0          10s
webhook-b5c5fddf7-d5d79                                  1/1     Running     0          11s
```

The `net-istio-webhook-xxx` is expected to be up and running. You can also check the logs.

```
❯ kubectl exec -ti -n knative-serving net-istio-webhook-698576f4f9-d6dzb exec -- bash
_daemon_@net-istio-webhook-698576f4f9-d6dzb:/$ pebble logs 
2024-11-28T13:03:06.549Z [net-istio-webhook] {"severity":"INFO","timestamp":"2024-11-28T13:03:06.549283642Z","logger":"net-istio-webhook","caller":"webhook/admission.go:93","message":"Webhook ServeHTTP request=&http.Request{Method:\"POST\", URL:(*url.URL)(0xc000601ef0), Proto:\"HTTP/1.1\", ProtoMajor:1, ProtoMinor:1, Header:http.Header{\"Accept\":[]string{\"application/json, */*\"}, \"Accept-Encoding\":[]string{\"gzip\"}, \"Content-Length\":[]string{\"27231\"}, \"Content-Type\":[]string{\"application/json\"}, \"User-Agent\":[]string{\"kube-apiserver-admission\"}}, Body:(*http.body)(0xc0008c4480), GetBody:(func() (io.ReadCloser, error))(nil), ContentLength:27231, TransferEncoding:[]string(nil), Close:false, Host:\"net-istio-webhook.knative-serving.svc:443\", Form:url.Values(nil), PostForm:url.Values(nil), MultipartForm:(*multipart.Form)(nil), Trailer:http.Header(nil), RemoteAddr:\"192.168.100.34:18437\", RequestURI:\"/defaulting?timeout=10s\", TLS:(*tls.ConnectionState)(0xc0004c7ad0), Cancel:(<-chan struct {})(nil), Response:(*http.Response)(nil), ctx:(*context.cancelCtx)(0xc0009da410)}","commit":"916ac51"}
...
```