### PR TITLE
feat: integrate operator `webhook` rock

### DIFF
--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -28,4 +28,4 @@ resources:
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.12.4
+    upstream-source: charmedkubeflow/knative-webhook:1.12.4-d887d34


### PR DESCRIPTION
Closes #244 

Integrates the `knative-operator-webhook-image` resource in the `knative-operator` charm to use the rock published from [this Push job](https://github.com/canonical/knative-rocks/actions/runs/12064975175/job/33643304750).