### PR TITLE
ci: bump juju to 3.6 + charmcraft to 3.x/stable

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -68,8 +68,8 @@ jobs:
         with:
           provider: microk8s
           channel: 1.26-strict/stable
-          juju-channel: 3.4/stable
-          charmcraft-channel: latest/candidate
+          juju-channel: 3.6/stable
+          charmcraft-channel: 3.x/stable
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
       - name: Run integration tests
@@ -102,8 +102,8 @@ jobs:
         with:
           provider: microk8s
           channel: 1.26-strict/stable
-          juju-channel: 3.4/stable
-          charmcraft-channel: latest/candidate
+          juju-channel: 3.6/stable
+          charmcraft-channel: 3.x/stable
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,4 +91,4 @@ jobs:
           charm-path: ${{ matrix.charm-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: 3.x/stable


### PR DESCRIPTION
* Bump juju to 3.6/stable
* For uniformity, use charmcraft from 3.x/stable

Ref canonical/bundle-kubeflow#1176