### PR TITLE
Integrate `net-istio-controller/controller` rock

### DIFF
--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 CUSTOM_IMAGE_CONFIG_NAME = "custom_images"
 DEFAULT_IMAGES = {
     "net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.12.3-b455143",
-    "net-istio-controller/controller": "charmedkubeflow/net-istio-controller:1.12.3-dc35fc7",
+    "net-istio-controller/controller": "charmedkubeflow/net-istio-controller:1.12.3-2d7219d",
 }
 
 

--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -28,7 +28,10 @@ logger = logging.getLogger(__name__)
 
 
 CUSTOM_IMAGE_CONFIG_NAME = "custom_images"
-DEFAULT_IMAGES = {"net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.12.3-b455143"}
+DEFAULT_IMAGES = {
+    "net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.12.3-b455143",
+    "net-istio-controller/controller": "charmedkubeflow/net-istio-controller:1.12.3-dc35fc7",
+}
 
 
 class KnativeServingCharm(CharmBase):


### PR DESCRIPTION
Closes #242 

This PR adds the rock for `net-istio-controller/controller` to the `DEFAULT_IMAGES` dictionary.

To test:
```
tox -e integration -- --model kubeflow --keep-models -vv -s
```