### PR TITLE
chore: bump otel-collector to 0.117.0

### DIFF
--- a/charms/knative-operator/config.yaml
+++ b/charms/knative-operator/config.yaml
@@ -2,6 +2,6 @@
 # See LICENSE file for licensing details.
 options:
   otel-collector-image:
-    default: "otel/opentelemetry-collector:0.110.0"
+    default: "otel/opentelemetry-collector:0.117.0"
     type: string
     description: Image to use by the otel collector Deployment.

--- a/charms/knative-operator/src/manifests/observability/collector.yaml.j2
+++ b/charms/knative-operator/src/manifests/observability/collector.yaml.j2
@@ -10,7 +10,7 @@ data:
         endpoint: "0.0.0.0:55678"
 
     exporters:
-      logging:
+      debug:
       prometheus:
         endpoint: "0.0.0.0:8889"
     extensions:


### PR DESCRIPTION
Update otel-collector to use version 0.117.0. Due to deprecation of `logging` configuration, update collector.yaml.j2 according to upstream instruction in open-telemetry/opentelemetry-collector#11337

Fix #235 


#### Testing
Observability tests should pass. For manual testing:
```bash
juju deploy knative-operator --channel latest/edge/pr-274 --trust --base ubuntu@20.04
juju deploy knative-eventing --channel latest/edge/pr-274 --trust --base ubuntu@20.04 --config namespace="knative-eventing"
juju deploy knative-serving --channel latest/edge/pr-274 --trust --base ubuntu@20.04 --config namespace="knative-serving" --config istio.gateway.namespace="kubeflow" --config istio.gateway.name="kubeflow-gateway"
juju deploy prometheus-k8s --trust --channel latest/stable
juju relate prometheus-k8s:metrics-endpoint knative-operator:metrics-endpoint
juju integrate knative-eventing:otel-collector knative-operator:otel-collector
juju integrate knative-serving:otel-collector knative-operator:otel-collector
# Navigate to prometheus ip from juju status `<prometheus-ip>:9090` in browser and check that there are `_eventing_` and `_serving_` metrics 
```