### PR TITLE
refactor: use main event handler and defer it if Knative CRDs are not found

### DIFF
--- a/charms/knative-eventing/src/charm.py
+++ b/charms/knative-eventing/src/charm.py
@@ -15,10 +15,12 @@ import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler as KRH  # noqa N813
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
+from lightkube import Client
 from lightkube.core.exceptions import ApiError
+from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
 from image_management import parse_image_config, remove_empty_images, update_images
 from lightkube_custom_resources.operator import KnativeEventing_v1beta1  # noqa F401
@@ -40,8 +42,7 @@ class KnativeEventingCharm(CharmBase):
         self._namespace = self.model.name
         self._resource_handler = None
 
-        self.framework.observe(self.on.install, self._on_install)
-        self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.config_changed, self._main)
         self.framework.observe(
             self.on["otel-collector"].relation_changed, self._on_otel_collector_relation_changed
         )
@@ -84,14 +85,23 @@ class KnativeEventingCharm(CharmBase):
             )
         return custom_images
 
-    def _on_install(self, _):
+    def _main(self, event):
         if not self.model.config["namespace"]:
             self.model.unit.status = BlockedStatus("Config item `namespace` must be set")
             return
-        self._apply_and_set_status()
-
-    def _on_config_changed(self, _):
-        self._apply_and_set_status()
+        # Check the KnativeServing CRD is present; otherwise defer
+        lightkube_client = Client()
+        try:
+            lightkube_client.get(CustomResourceDefinition, "knativeservings.operator.knative.dev")
+            self._apply_and_set_status()
+        except ApiError as e:
+            if e.status.code == 404:
+                self.model.unit.status = WaitingStatus(
+                    "Waiting for knative-operator CRDs to be present."
+                )
+                event.defer()
+            else:
+                raise e
 
     def _on_otel_collector_relation_changed(self, _):
         """Event handler for on['otel-collector'].relation_changed."""

--- a/charms/knative-eventing/src/charm.py
+++ b/charms/knative-eventing/src/charm.py
@@ -12,7 +12,7 @@ import traceback
 from pathlib import Path
 
 import yaml
-from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler as KRH  # noqa N813
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from lightkube import Client
@@ -101,7 +101,9 @@ class KnativeEventingCharm(CharmBase):
                 )
                 event.defer()
             else:
-                raise e
+                raise GenericCharmRuntimeError(
+                    f"Lightkube get CRD failed with error code: {e.status.code}"
+                ) from e
 
     def _on_otel_collector_relation_changed(self, _):
         """Event handler for on['otel-collector'].relation_changed."""

--- a/charms/knative-eventing/tests/unit/test_charm.py
+++ b/charms/knative-eventing/tests/unit/test_charm.py
@@ -8,7 +8,7 @@ import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from charmed_kubeflow_chisme.lightkube.mocking import FakeApiError
 from lightkube import ApiError
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
 from charm import CUSTOM_IMAGE_CONFIG_NAME, DEFAULT_IMAGES
 
@@ -42,28 +42,41 @@ class _FakeApiError(ApiError):
 def test_events(harness, mocked_lightkube_client):
     # Test install and config_changed event handlers are called
     harness.begin()
-    harness.charm._on_install = MagicMock()
-    harness.charm._on_config_changed = MagicMock()
+    harness.charm._main = MagicMock()
     harness.charm._on_otel_collector_relation_changed = MagicMock()
 
-    harness.charm.on.install.emit()
-    harness.charm._on_install.assert_called_once()
-
     harness.charm.on.config_changed.emit()
-    harness.charm._on_config_changed.assert_called_once()
+    harness.charm._main.assert_called_once()
 
     rel_id = harness.add_relation("otel-collector", "app")
     harness.update_relation_data(rel_id, "app", {"some-key": "some-value"})
     harness.charm._on_otel_collector_relation_changed.assert_called_once()
 
 
-def test_on_install_active(harness, mocked_lightkube_client):
-    harness.begin()
+@patch("charm.Client")
+def test_active(lk_client, harness, mocked_lightkube_client):
+    harness.begin_with_initial_hooks()
     harness.update_config({"namespace": "test"})
+    rel_id = harness.add_relation("otel-collector", "app")
+    harness.update_relation_data(rel_id, "app", {"some-key": "some-value"})
     harness.charm.resource_handler.apply = MagicMock()
     harness.charm.resource_handler.apply.return_value = None
-    harness.charm.on.install.emit()
     assert harness.model.unit.status == ActiveStatus()
+
+
+@patch("charm.Client")
+def test_missing_knative_serving_crd(lk_client, harness, mocker, mocked_lightkube_client):
+    harness.begin()
+
+    # Set the side effect of Client to a FakeApiError
+    lk_client.return_value.get.side_effect = _FakeApiError(code=404)
+
+    # Set the relation to otel-collector
+    rel_id = harness.add_relation("otel-collector", "app")
+    harness.update_relation_data(rel_id, "app", {"some-key": "some-value"})
+
+    harness.update_config({"namespace": "test"})
+    assert isinstance(harness.model.unit.status, WaitingStatus)
 
 
 @pytest.mark.parametrize(

--- a/charms/knative-eventing/tests/unit/test_charm.py
+++ b/charms/knative-eventing/tests/unit/test_charm.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
 from charmed_kubeflow_chisme.lightkube.mocking import FakeApiError
 from lightkube import ApiError
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
@@ -65,7 +65,7 @@ def test_active(lk_client, harness, mocked_lightkube_client):
 
 
 @patch("charm.Client")
-def test_missing_knative_serving_crd(lk_client, harness, mocker, mocked_lightkube_client):
+def test_missing_knative_eventing_crd(lk_client, harness, mocker, mocked_lightkube_client):
     harness.begin()
 
     # Set the side effect of Client to a FakeApiError
@@ -77,6 +77,21 @@ def test_missing_knative_serving_crd(lk_client, harness, mocker, mocked_lightkub
 
     harness.update_config({"namespace": "test"})
     assert isinstance(harness.model.unit.status, WaitingStatus)
+
+
+@patch("charm.Client")
+def test_error_getting_knative_eventing_crd(lk_client, harness, mocker, mocked_lightkube_client):
+    harness.begin()
+
+    # Set the side effect of Client to a FakeApiError
+    lk_client.return_value.get.side_effect = _FakeApiError(code=403)
+
+    # Set the relation to otel-collector
+    rel_id = harness.add_relation("otel-collector", "app")
+    harness.update_relation_data(rel_id, "app", {"some-key": "some-value"})
+
+    with pytest.raises(GenericCharmRuntimeError):
+        harness.update_config({"namespace": "test"})
 
 
 @pytest.mark.parametrize(

--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -12,7 +12,7 @@ import traceback
 from pathlib import Path
 
 import yaml
-from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler as KRH  # noqa N813
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charms.istio_pilot.v0.istio_gateway_info import GatewayProvider
@@ -116,7 +116,9 @@ class KnativeServingCharm(CharmBase):
                 )
                 event.defer()
             else:
-                raise e
+                raise GenericCharmRuntimeError(
+                    f"Lightkube get CRD failed with error code: {e.status.code}"
+                ) from e
 
     def _on_ingress_gateway_relation_changed(self, _) -> None:
         self._send_ingress_gateway_data()


### PR DESCRIPTION
The Knative Serving and Eventing charms have a strong dependency on knative-operator, as it is the application that applies the KnativeServing and KnativeEventing CRDs and has the business logic to reconcile such CRs. Because the Knative Serving and Eventing charms depend entirely on the existence of those CRDs, this commit refactors the charms logic to:
1. Use a main event handler that can be deferred in case the required CRDs are not present
2. Remove any operation for the on_install event, and use the main event handler for config_changed as it is guaranteed that it'll be triggered right after on_install

Fixes #156

#### Manual testing

1. Deploy knative-{serving|eventing}
2. Depending on which charm, you may need to run some configs, for example, for serving:

```
juju config knative-serving namespace="knative-serving"
```

3. Observe that in the absence of knative-operator, the charm goes to waiting status:

```
knative-serving/0*       waiting   idle   10.1.205.36         Waiting for knative-operator CRDs to be present.
```

4. Deploy the `knative-operator` charm

```
juju deploy knative-operator --channel 1.12/stable --trust
```

5. (optional) If you want to speed up things, you can update the hook interval

```
juju model-config update-status-hook-interval=5s
```

6. Observe that the message goes away and the error is not present any more

```
knative-operator/0*      active    idle   10.1.205.35
knative-serving/0*       active    idle   10.1.205.36
```