### PR TITLE
fix: fix the name of CRD that knative-eventing looks for

### DIFF
--- a/charms/knative-eventing/src/charm.py
+++ b/charms/knative-eventing/src/charm.py
@@ -92,7 +92,7 @@ class KnativeEventingCharm(CharmBase):
         # Check the KnativeServing CRD is present; otherwise defer
         lightkube_client = Client()
         try:
-            lightkube_client.get(CustomResourceDefinition, "knativeservings.operator.knative.dev")
+            lightkube_client.get(CustomResourceDefinition, "knativeeventings.operator.knative.dev")
             self._apply_and_set_status()
         except ApiError as e:
             if e.status.code == 404:


### PR DESCRIPTION
In a previous commit, a check for knative CRDs was introduced, but for knative-eventing, it was incorrectly set up. This commit fixes the name of the CRD that the knative-eventing charm should look up for.