### PR TITLE
refactor(ci): Remove duplicate code by merging integration environments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
 
   bundle-integration:
     name: Bundle integration tests
-    needs: 
+    needs:
       - build
     strategy:
       matrix:
@@ -145,22 +145,20 @@ jobs:
         run: |
           sg snap_microk8s -c "tox -vve ${{ matrix.environment }} -- --model knative-test --charms-path=${{ github.workspace }}/charms/"
 
-      - run: kubectl get pod/prometheus-k8s-0 -n knative-test -o=jsonpath='{.status}'
-        if: failure() && ${{ matrix.environment=='cos-integration' }} 
-
-      - run: kubectl get pod/knative-operator-0 -nknative-test -o=jsonpath='{.status}'
+      - name: Run kubectl get all
+        run: kubectl get all -A
         if: failure()
 
-      - run: kubectl get all -A
+      - name: Print list of crds
+        run: kubectl get crds
         if: failure()
 
-      - run: kubectl get crds
+      - name: Get juju status
+        run: juju status
         if: failure()
 
-      - run: juju status
-        if: failure()
-
-      - uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+      - name: Collect charm debug artifacts
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
         if: failure()
 
   release:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,10 +105,13 @@ jobs:
     with:
       path-to-charm-directory: ${{ matrix.charm }}
 
-  integration-charm-deployment:
-    name: Integration Test
-    needs:
+  bundle-integration:
+    name: Bundle integration tests
+    needs: 
       - build
+    strategy:
+      matrix:
+        environment: [ "integration", "cos-integration" ]
     runs-on: ubuntu-20.04
     steps:
       # Ideally we'd use self-hosted runners, but this effort is still not stable
@@ -140,65 +143,18 @@ jobs:
 
       - name: Run integration tests
         run: |
-          sg snap_microk8s -c "juju add-model knative-test"
-          sg snap_microk8s -c "tox -vve integration -- --model knative-test --charms-path=${{ github.workspace }}/charms"
+          sg snap_microk8s -c "tox -vve ${{ matrix.environment }} -- --model knative-test --charms-path=${{ github.workspace }}/charms/"
+
+      - run: kubectl get pod/prometheus-k8s-0 -n knative-test -o=jsonpath='{.status}'
+        if: failure() && ${{ matrix.environment=='cos-integration' }} 
+
+      - run: kubectl get pod/knative-operator-0 -nknative-test -o=jsonpath='{.status}'
+        if: failure()
 
       - run: kubectl get all -A
         if: failure()
 
       - run: kubectl get crds
-        if: failure()
-
-      - run: juju status
-        if: failure()
-
-      - uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        if: failure()
-
-  integration-observability:
-    name: Observability Integration Test
-    needs:
-      - build
-    runs-on: ubuntu-20.04
-    steps:
-      # Ideally we'd use self-hosted runners, but this effort is still not stable
-      # This action will remove unused software (dotnet, haskell, android libs, codeql,
-      # and docker images) from the GH runner.
-      # This leaves ~45GB free as of 2024-04-10, but this amount has varied as GH changed their
-      # runners
-      - name: Maximise GH runner space
-        uses: jlumbroso/free-disk-space@v1.3.1
-
-      - name: Check out repo
-        uses: actions/checkout@v4
-
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-          channel: 1.31-strict/stable
-          juju-channel: 3.6/stable
-
-      - name: Download packed charm(s)
-        id: download-charms
-        timeout-minutes: 5
-        uses: actions/download-artifact@v4
-        with:
-          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
-          merge-multiple: true
-
-      - name: Run integration tests
-        run: |
-          sg snap_microk8s -c "juju add-model cos-test"
-          sg snap_microk8s -c "tox -vve cos-integration -- --model cos-test --charms-path=${{ github.workspace }}/charms"
-
-      - run: kubectl get pod/prometheus-k8s-0 -n cos-test -o=jsonpath='{.status}'
-        if: failure()
-
-      - run: kubectl get pod/knative-operator-0 -n cos-test -o=jsonpath='{.status}'
-        if: failure()
-
-      - run: kubectl get all -A
         if: failure()
 
       - run: juju status


### PR DESCRIPTION
`integration-charm-deployment` and `integration-charm-deployment` were running the [bundle integration tests](https://github.com/canonical/knative-operators/tree/main/tests). Merge those into one called `bundle-integration` for clarity in order to remove duplicate code and run both `cos-integration` and vanilla `integration` environment using a matrix.

A follow-up PR will enable charm integration tests also (see https://github.com/canonical/knative-operators/issues/288)