### PR TITLE
fix(ci): Run charm integration tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,63 @@ jobs:
     with:
       path-to-charm-directory: ${{ matrix.charm }}
 
+  integration:
+    name: Integration tests
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        charm: [operator]
+    runs-on: ubuntu-20.04
+    steps:
+      # Ideally we'd use self-hosted runners, but this effort is still not stable
+      # This action will remove unused software (dotnet, haskell, android libs, codeql,
+      # and docker images) from the GH runner.
+      # This leaves ~45GB free as of 2024-04-10, but this amount has varied as GH changed their
+      # runners
+      - name: Maximise GH runner space
+        uses: jlumbroso/free-disk-space@v1.3.1
+
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          channel: 1.31-strict/stable
+          juju-channel: 3.6/stable
+          microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
+
+      - name: Download packed charm(s)
+        id: download-charms
+        timeout-minutes: 5
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
+
+      - name: Run integration tests
+        run: |
+          sg snap_microk8s -c "tox -e ${{ matrix.charm }}-integration -- --model knative-test --charm-path=${{ github.workspace }}/charms/knative-${{ matrix.charm }}/knative-${{ matrix.charm }}_ubuntu@20.04-amd64.charm"
+
+      - name: Run kubectl get all
+        run: kubectl get all -A
+        if: failure()
+
+      - name: Print list of crds
+        run: kubectl get crds
+        if: failure()
+
+      - name: Get juju status
+        run: juju status
+        if: failure()
+
+      - name: Collect charm debug artifacts
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+        if: failure()
+
   bundle-integration:
     name: Bundle integration tests
     needs:

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ setenv =
   eventing: CHARM = eventing
   unit: TYPE = unit
   lint: TYPE = lint
+  integration: TYPE = integration
 passenv =
   KUBECONFIG
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
 passenv =
   KUBECONFIG
 commands =
-  tox -c charms/knative-{env:CHARM} -e {env:TYPE} {posargs}
+  tox -c charms/knative-{env:CHARM} -e {env:TYPE} -- {posargs}
 
 [testenv:update-requirements]
 allowlist_externals =


### PR DESCRIPTION
Run charm integration tests in CI workflows.

Fix #288