### PR TITLE
chore: update manifests to v1.16 for CKF 1.10

### DIFF
--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.12.4"
+    default: "1.16.0"
     description: Version of knative-eventing component.
     type: string
   namespace:

--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -24,8 +24,8 @@ resources:
   knative-operator-image:
     type: oci-image
     description: OCI image for knative-operator
-    upstream-source: charmedkubeflow/knative-operator:1.12.4-3f2a424
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.16.0
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component
-    upstream-source: charmedkubeflow/knative-webhook:1.12.4-d887d34
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.16.0

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -17,6 +17,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-serving-operator-aggregated
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 aggregationRule:
   clusterRoleSelectors:
 # This (along with escalate below) allows the Operator to pick up any
@@ -83,6 +86,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-operator
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 rules:
 - apiGroups:
   - operator.knative.dev
@@ -263,6 +269,7 @@ rules:
   - knative-serving-operator
   verbs:
   - delete
+
 # for contour TLS
 - apiGroups:
   - projectcontour.io
@@ -278,6 +285,7 @@ rules:
   - delete
   - deletecollection
   - patch
+
 # for security-guard
 - apiGroups:
   - guard.security.knative.dev
@@ -320,6 +328,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-eventing-operator
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 rules:
   - apiGroups:
       - operator.knative.dev
@@ -502,6 +513,7 @@ rules:
       - exchanges/status
     verbs:
       - get
+
   # for Kafka eventing source
   - apiGroups:
       - keda.sh
@@ -552,6 +564,8 @@ rules:
       - watch
       - update
       - patch
+      - create
+      - delete
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -674,13 +688,41 @@ rules:
       - deployments
     verbs:
       - deletecollection
+
+  # Eventing TLS
+  - apiGroups:
+      - "cert-manager.io"
+    resources:
+      - certificates
+      - issuers
+      - clusterissuers
+    verbs:
+      - create
+      - delete
+      - update
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - bundles
+    verbs:
+      - create
+      - delete
+      - update
+      - list
+      - get
+      - watch
 ---
-# Source: knative/operator/config/rbac/role_binding.yaml
 # TODO: Consider restriction of non-aggregated role to knativeservings namespaces.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -695,6 +737,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -704,26 +749,15 @@ subjects:
   name: {{ name }}-workload
   namespace: {{ namespace }}
 ---
-
-# Copyright 2022 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 # Source: knative/operator/config/rbac/webhook_role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: default
+  namespace: {{ namespace }}
   name: knative-operator-webhook
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 rules:
   # For manipulating certs into secrets.
   - apiGroups:
@@ -742,6 +776,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-operator-webhook
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:
@@ -818,25 +855,14 @@ rules:
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
 # Source: knative/operator/config/rbac/webhook_role_binding.yaml
-# Copyright 2022 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: default
+  namespace: {{ namespace }}
   name: knative-operator-webhook
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 subjects:
   - kind: ServiceAccount
     name: knative-operator-webhook
@@ -850,6 +876,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-operator-webhook
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -859,35 +888,19 @@ subjects:
   name: knative-operator-webhook
   namespace: {{ namespace }}
 ---
-# Source: knative/operator/config/rbac/clusterrole_aggregated_binding.yaml
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.12.4"
-    app.kubernetes.io/version: "1.12.4"
-    app.kubernetes.io/part-of: knative-operator
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: knative-serving-operator-aggregated
 subjects:
-  - kind: ServiceAccount
+- kind: ServiceAccount
     name: {{ name }}-workload
     namespace: {{ namespace }}
 ---
@@ -896,9 +909,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.12.4"
-    app.kubernetes.io/version: "1.12.4"
-    app.kubernetes.io/part-of: knative-operator
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -913,9 +925,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated
   labels:
-    operator.knative.dev/release: "v1.12.4"
-    app.kubernetes.io/version: "1.12.4"
-    app.kubernetes.io/part-of: knative-operator
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -930,9 +941,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated-stable
   labels:
-    operator.knative.dev/release: "v1.12.4"
-    app.kubernetes.io/version: "1.12.4"
-    app.kubernetes.io/part-of: knative-operator
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -942,23 +952,11 @@ subjects:
     name: {{ name }}-workload
     namespace: {{ namespace }}
 ---
-# Source: knative/operator/config/rbac/webhook_service_account.yaml
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: knative-operator-webhook
   namespace: {{ namespace }}
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator

--- a/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/auth_manifests.yaml.j2
@@ -715,6 +715,7 @@ rules:
       - get
       - watch
 ---
+# Source: knative/operator/config/rbac/role_binding.yaml
 # TODO: Consider restriction of non-aggregated role to knativeservings namespaces.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -888,6 +889,7 @@ subjects:
   name: knative-operator-webhook
   namespace: {{ namespace }}
 ---
+# Source: knative/operator/config/rbac/clusterrole_aggregated_binding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -952,6 +954,7 @@ subjects:
     name: {{ name }}-workload
     namespace: {{ namespace }}
 ---
+# Source: knative/operator/config/rbac/webhook_service_account.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charms/knative-operator/src/manifests/config_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/config_manifests.yaml.j2
@@ -1,4 +1,3 @@
-# Source: knative/operator/config/manager/config-logging-configmap.yaml
 # Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-logging
   namespace: {{ namespace }}
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 data:
   _example: |
     ################################
@@ -79,6 +81,9 @@ kind: ConfigMap
 metadata:
   name: config-observability
   namespace: {{ namespace }}
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 data:
   _example: |
     ################################
@@ -107,35 +112,6 @@ data:
     # access to Kibana after setting up kubectl proxy.
     logging.revision-url-template: |
       http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
-
-    # If non-empty, this enables queue proxy writing request logs to stdout.
-    # The value determines the shape of the request logs and it must be a valid go text/template.
-    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
-    # by most collection agents and will split the request logs into multiple records.
-    #
-    # The following fields and functions are available to the template:
-    #
-    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
-    # representing an HTTP request received by the server.
-    #
-    # Response:
-    # struct {
-    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
-    #   Size    int       // An int representing the size of the response.
-    #   Latency float64   // A float64 representing the latency of the response in seconds.
-    # }
-    #
-    # Revision:
-    # struct {
-    #   Name          string  // Knative revision name
-    #   Namespace     string  // Knative revision namespace
-    #   Service       string  // Knative service name
-    #   Configuration string  // Knative configuration name
-    #   PodName       string  // Name of the pod hosting the revision
-    #   PodIP         string  // IP of the pod hosting the revision
-    # }
-    #
-    logging.request-log-template: <<Example removed because it messes with charmed kubeflow's templating.  See upstream's yaml for example of this setting>>
 
     # metrics.backend-destination field specifies the system metrics destination.
     # It supports either prometheus (the default) or stackdriver.

--- a/charms/knative-operator/src/manifests/config_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/config_manifests.yaml.j2
@@ -1,3 +1,4 @@
+# Source: knative/operator/config/manager/config-logging-configmap.yaml
 # Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
@@ -17,6 +17,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: knativeservings.operator.knative.dev
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 spec:
   group: operator.knative.dev
   versions:
@@ -1151,6 +1154,20 @@ spec:
                             type: object
                         type: object
                       type: array
+              namespace:
+                description: A field of namespace name to override the labels and annotations
+                type: object
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels overrides labels for the namespace and its template.
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations overrides labels for the namespace and its template.
+                    type: object
               deployments:
                 description: A mapping of deployment name to override
                 type: array
@@ -2210,6 +2227,12 @@ spec:
                         - type: string
                       description: An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
                       x-kubernetes-int-or-string: true
+                    maxUnavailable:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: 	An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+                      x-kubernetes-int-or-string: true
               ingress:
                 description: The ingress configuration for Knative Serving
                 properties:
@@ -2259,6 +2282,29 @@ spec:
                                       format: string
                                       type: string
                                   type: object
+                                tls:
+                                  nullable: true
+                                  oneOf:
+                                  - required:
+                                    - mode
+                                    - credentialName
+                                  - required:
+                                    - httpsRedirect
+                                  properties:
+                                    mode:
+                                      description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
+                                      format: string
+                                      type: string
+                                    credentialName:
+                                      description: TLS certificate name.
+                                      format: string
+                                      type: string
+                                    httpsRedirect:
+                                      description: If set to true, the load balancer will send a 301 redirect
+                                        to HTTPS for all HTTP requests. Should be used only for HTTP listener,
+                                        is mutually exclusive with all other TLS options.
+                                      type: boolean
+                                  type: object
                               type: object
                             type: array
                         type: object
@@ -2296,6 +2342,29 @@ spec:
                                       description: The protocol exposed on the port.
                                       format: string
                                       type: string
+                                  type: object
+                                tls:
+                                  nullable: true
+                                  oneOf:
+                                  - required:
+                                    - mode
+                                    - credentialName
+                                  - required:
+                                    - httpsRedirect
+                                  properties:
+                                    mode:
+                                      description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
+                                      format: string
+                                      type: string
+                                    credentialName:
+                                      description: TLS certificate name.
+                                      format: string
+                                      type: string
+                                    httpsRedirect:
+                                      description: If set to true, the load balancer will send a 301 redirect
+                                        to HTTPS for all HTTP requests. Should be used only for HTTP listener,
+                                        is mutually exclusive with all other TLS options.
+                                      type: boolean
                                   type: object
                               type: object
                             type: array
@@ -2442,7 +2511,7 @@ spec:
       clientConfig:
         service:
           name: operator-webhook
-          namespace: default
+          namespace: {{ namespace }}
           path: /resource-conversion
 ---
 # Source: knative/operator/config/crd/bases/operator.knative.dev_knativeeventings.yaml
@@ -2464,6 +2533,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: knativeeventings.operator.knative.dev
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
 spec:
   group: operator.knative.dev
   versions:
@@ -3587,6 +3659,20 @@ spec:
                             type: object
                         type: object
                       type: array
+              namespace:
+                description: A field of namespace name to override the labels and annotations
+                type: object
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels overrides labels for the namespace and its template.
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations overrides labels for the namespace and its template.
+                    type: object
               deployments:
                 description: A mapping of deployment name to override
                 type: array
@@ -4646,6 +4732,12 @@ spec:
                         - type: string
                       description: An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
                       x-kubernetes-int-or-string: true
+                    maxUnavailable:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: 	An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+                      x-kubernetes-int-or-string: true
               source:
                 description: The source configuration for Knative Eventing
                 properties:
@@ -4806,5 +4898,5 @@ spec:
       clientConfig:
         service:
           name: operator-webhook
-          namespace: default
+          namespace: {{ namespace }}
           path: /resource-conversion

--- a/charms/knative-operator/src/manifests/operator_ns.yaml.j2
+++ b/charms/knative-operator/src/manifests/operator_ns.yaml.j2
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: knative-operator
+  name: {{ namespace }}

--- a/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
@@ -1,5 +1,5 @@
 # Source: knative/operator/config/webhook/webhook-secret.yaml
-# Copyright 2022 The Tekton Authors
+# Copyright 2022 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ metadata:
   namespace: {{ namespace }}
   labels:
     app.kubernetes.io/component: operator-webhook
-    operator.knative.dev/release: "v1.12.4"
-    app.kubernetes.io/version: "v1.12.4"
+    app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.

--- a/charms/knative-operator/src/manifests/service_account.yaml.j2
+++ b/charms/knative-operator/src/manifests/service_account.yaml.j2
@@ -18,3 +18,6 @@ kind: ServiceAccount
 metadata:
   name: {{ name }}-workload
   namespace: {{ namespace }}
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator

--- a/charms/knative-operator/src/manifests/webhook-service.yaml
+++ b/charms/knative-operator/src/manifests/webhook-service.yaml
@@ -18,6 +18,9 @@ kind: Service
 metadata:
   labels:
     role: knative-operator-webhook
+    app.kubernetes.io/component: operator-webhook
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-operator
   name: knative-operator-webhook
   namespace: {{ namespace }}
 spec:

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.12.4"
+    default: "1.16.0"
     description: Version of knative-serving component.
     type: string
   namespace:

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -33,9 +33,9 @@ SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./s
 wget -q "${KNATIVE_SERVING_REPO_DOWNLOAD_URL}/knative-v${KNATIVE_SERVING_VERSION}/serving-post-install-jobs.yaml"
 SERVING_IMAGE_LIST+=($(yq -N '.spec.template.spec.containers | .[] | .image' ./serving-post-install-jobs.yaml))
 
-# For Serving 1.12.4 (CKF 1.9) we have to use 1.12.3 for net-istio
-# https://github.com/kubeflow/manifests/pull/2709
-NET_ISTIO_VERSION="1.12.3"
+# For Serving 1.16.0 (CKF 1.10) we have to use 1.16.0 for net-istio
+# https://github.com/kubeflow/manifests/blob/v1.10.0-rc.0/common/knative/README.md?plain=1#L8
+NET_ISTIO_VERSION="1.16.0"
 NET_ISTIO_REPO_DOWNLOAD_URL=https://github.com/knative-extensions/net-istio/releases/download/
 NET_ISTIO_IMAGE_LIST=()
 wget -q "${NET_ISTIO_REPO_DOWNLOAD_URL}knative-v${NET_ISTIO_VERSION}/net-istio.yaml"


### PR DESCRIPTION
Updates the manifests and images script based on the changes in https://github.com/knative/operator/tree/knative-v1.16.0