### PR TITLE
Use rocks for operator and webhook

### DIFF
--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -24,8 +24,8 @@ resources:
   knative-operator-image:
     type: oci-image
     description: OCI image for knative-operator
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.16.0
+    upstream-source: charmedkubeflow/knative-operator:1.16.0-7e998f4
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.16.0
+    upstream-source: charmedkubeflow/knative-webhook:1.16.0-f82a64b


### PR DESCRIPTION
This is both for the 1.10 release, and also for https://github.com/canonical/knative-operators/issues/291

## Changes
Updates the rocks for 1.16.0, which also includes our patch for `readOnlyRootFilesystem: false`