### PR TITLE
fix: use charmcraft promote in promote.yaml workflow

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -18,14 +18,15 @@ jobs:
   promote-charm:
     name: Promote charm
     runs-on: ubuntu-20.04
+    env:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.6.2
-        with:
-          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          destination-channel: ${{ github.event.inputs.destination-channel }}
-          origin-channel: ${{ github.event.inputs.origin-channel }}
-          tag-prefix: ${{ github.event.inputs.charm-name }}
-          charm-path: charms/${{ github.event.inputs.charm-name}}
+      - name: Install charmcraft
+        run: |
+          sudo snap install charmcraft --classic --channel latest/stable
+      - name: Run charmcraft promote
+        run: |
+          charmcraft promote --name ${{ github.event.inputs.charm-name }} \
+                              --from-channel ${{ github.event.inputs.origin-channel }} \
+                              --to-channel ${{ github.event.inputs.destination-channel }} \
+                              --yes


### PR DESCRIPTION
Ref https://github.com/canonical/bundle-kubeflow/issues/1202

Rewrites the promote.yaml workflow to use `charmcraft promote` command instead of the `release-charm` action. We can no longer use the `release-charm` action because it relies on having GH releases in the repo, which we have stopped producing since migrating  our CI to `data-platform-workflows`. See https://github.com/canonical/bundle-kubeflow/issues/1202 for more details.