### PR TITLE
chore: integrate operator rock v1.16

### DIFF
--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -24,7 +24,7 @@ resources:
   knative-operator-image:
     type: oci-image
     description: OCI image for knative-operator
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.16.0
+    upstream-source: charmedkubeflow/knative-operator:1.16.0-7e998f4
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-6945

Integrates the rock into `knative-operator-image` resource published by [this on push](https://github.com/canonical/knative-rocks/actions/runs/13264306275/job/37028660962)