### PR TITLE
chore: integrate webhook rock v1.16

### DIFF
--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -28,4 +28,4 @@ resources:
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.16.0
+    upstream-source: charmedkubeflow/knative-webhook:1.16.0-f82a64b


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-6946

Integrates the rock into `knative-operator-webhook-image` resource published by [this on push](https://github.com/canonical/knative-rocks/actions/runs/13178247512/job/36783281211)