### PR TITLE
chore: integrate net-istio-webhook:1.16.0-4214206 rock

### DIFF
--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 CUSTOM_IMAGE_CONFIG_NAME = "custom_images"
-DEFAULT_IMAGES = {"net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.12.3-b455143"}
+DEFAULT_IMAGES = {"net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.16.0-4214206"}
 
 
 class KnativeServingCharm(CharmBase):


### PR DESCRIPTION
Integrate net-istio-webhook:1.16.0-4214206 rock in preparation for a new release.

#### Testing

This component is not necessarily tested directly in the CI, but to make sure it works:

1. Deploy the knative-operator and knative-serving, their charm dependencies, and configure them properly (refer to the README.md in the root of this repo)
2. Wait for the knative-serving charm to go active and idle
3. In the `knative-serving` namespace, there should be a number of Pods with various names, we are interested in the `net-istio-webhook-***-***`
4. Verify that the Pod is in a `Running` state
5. Verify the service is running as expected by checking the logs of the Pod. It should be just showing info messages like:

```
2024-11-28T13:03:06.549Z [net-istio-webhook] {"severity":"INFO","timestamp":"2024-11-28T13:03:06.549283642Z","logger":"net-istio-webhook","caller":"webhook/admission.go:93","message":"Webhook ServeHTTP request=&http.Request{Method:\"POST\", URL:(*url.URL)(0xc000601ef0), Proto:\"HTTP/1.1\", ProtoMajor:1, ProtoMinor:1, Header:http.Header{\"Accept\":[]string{\"application/json, */*\"}, \"Accept-Encoding\":[]string{\"gzip\"}, \"Content-Length\":[]string{\"27231\"}, \"Content-Type\":[]string{\"application/json\"}, \"User-Agent\":[]string{\"kube-apiserver-admission\"}}, Body:(*http.body)(0xc0008c4480), GetBody:(func() (io.ReadCloser, error))(nil), ContentLength:27231, TransferEncoding:[]string(nil), Close:false, Host:\"net-istio-webhook.knative-serving.svc:443\", Form:url.Values(nil), PostForm:url.Values(nil), MultipartForm:(*multipart.Form)(nil), Trailer:http.Header(nil), RemoteAddr:\"192.168.100.34:18437\", RequestURI:\"/defaulting?timeout=10s\", TLS:(*tls.ConnectionState)(0xc0004c7ad0), Cancel:(<-chan struct {})(nil), Response:(*http.Response)(nil), ctx:(*context.cancelCtx)(0xc0009da410)}","commit":"916ac51"}
```