### PR TITLE
chore: integrate net-istio-controller and migrate rocks

### DIFF
--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -30,7 +30,11 @@ logger = logging.getLogger(__name__)
 
 
 CUSTOM_IMAGE_CONFIG_NAME = "custom_images"
-DEFAULT_IMAGES = {"net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.16.0-4214206"}
+DEFAULT_IMAGES = {
+    "net-istio-webhook/webhook": "charmedkubeflow/net-istio-webhook:1.16.0-4214206",
+    "net-istio-controller/controller": "charmedkubeflow/net-istio-controller:1.16.0-2ac1bad",
+    "migrate": "charmedkubeflow/migrate:1.16.0-36e94d5",
+}
 
 
 class KnativeServingCharm(CharmBase):


### PR DESCRIPTION
Integrate net-istio-controller and migrate rocks for 1.16

Close https://warthogs.atlassian.net/browse/KF-6988
Close https://warthogs.atlassian.net/browse/KF-6989

#### Testing
1, Follow instructions from #300 and then
1. Check pods `net-istio-controller-xxxx-xxx` and `storage-version-migration-serving-serving-1.16.0-xxxx` that are in `Running` state.
2. `kubectl exec` into the pods and check logs using `pebble logs` for errors. In my case, [logs from net-istio-controller](https://pastebin.canonical.com/p/dQTXZPDVpc/) and [logs from migrate pod](https://pastebin.canonical.com/p/KDFbXkJs9d/)