### PR TITLE
chore: integrate opentelemetry-collector rock

### DIFF
--- a/charms/knative-operator/config.yaml
+++ b/charms/knative-operator/config.yaml
@@ -2,6 +2,6 @@
 # See LICENSE file for licensing details.
 options:
   otel-collector-image:
-    default: "otel/opentelemetry-collector:0.117.0"
+    default: "ubuntu/opentelemetry-collector:0.120.0-24.04_stable"
     type: string
     description: Image to use by the otel collector Deployment.

--- a/charms/knative-operator/src/manifests/observability/collector.yaml.j2
+++ b/charms/knative-operator/src/manifests/observability/collector.yaml.j2
@@ -45,6 +45,8 @@ spec:
       containers:
       - name: collector
         args:
+        - --args  # This line and the one below are needed only for the rock,
+        - otelcol # they are required to pass the argument to the pebble service.
         - --config=/conf/collector.yaml
         image: {{ otel_collector_image }}
         resources:


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-7057


## Summary
* Integrates [otel collector rock](https://github.com/canonical/opentelemetry-collector-rock) by o11y team to `knative-operator` charm
* Bumps otel collector image from `0.117.0` to `0.120.0`
* Modifies the otel collector deployment yaml to pass the config argument to the pebble service. Note that this is needed due to the `entrypoint-service` not being set in the rock. See the change in https://github.com/canonical/opentelemetry-collector-rock/pull/10. Without passing `--args <pebble service name>` before the config arg, we'd get the error `error: unknown flag config`.

## Testing
Observability tests should pass. For manual testing:
```
juju deploy knative-operator --channel latest/edge/pr-303 --trust --base ubuntu@20.04
juju deploy knative-eventing --channel latest/edge/pr-303 --trust --base ubuntu@20.04 --config namespace="knative-eventing"
juju deploy knative-serving --channel latest/edge/pr-303 --trust --base ubuntu@20.04 --config namespace="knative-serving" --config istio.gateway.namespace="kubeflow" --config istio.gateway.name="kubeflow-gateway"
juju deploy prometheus-k8s --trust --channel latest/stable
juju integrate prometheus-k8s:metrics-endpoint knative-operator:metrics-endpoint
juju integrate knative-eventing:otel-collector knative-operator:otel-collector
juju integrate knative-serving:otel-collector knative-operator:otel-collector
# Navigate to prometheus ip from juju status `<prometheus-ip>:9090` in browser and check that there are `_eventing_` and `_serving_` metrics 
```
Results:
* eventing metrics
![Screenshot from 2025-03-03 14-50-16](https://github.com/user-attachments/assets/2ec5d0b0-2881-4f17-8581-ab55c0a1c463)
* serving metrics
![Screenshot from 2025-03-03 14-50-30](https://github.com/user-attachments/assets/9dced914-62cf-4365-bc9a-21075181dae7)
