### PR TITLE
fix(workaround): set constraints to setuptools-scm to avoid install loops

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          tox -e ${{ matrix.charm }}-integration -- --model knative-test --charm-path=${{ github.workspace }}/charms/knative-${{ matrix.charm }}/knative-${{ matrix.charm }}_ubuntu@20.04-amd64.charm
+          tox -e ${{ matrix.charm }}-integration -- --model knative-test --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@20.04-amd64.charm
 
       - name: Run kubectl get all
         run: kubectl get all -A

--- a/charms/knative-eventing/charmcraft.yaml
+++ b/charms/knative-eventing/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/knative-eventing/constraints.txt
+++ b/charms/knative-eventing/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/knative-operator/charmcraft.yaml
+++ b/charms/knative-operator/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/knative-operator/constraints.txt
+++ b/charms/knative-operator/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/knative-serving/charmcraft.yaml
+++ b/charms/knative-serving/charmcraft.yaml
@@ -36,6 +36,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source

--- a/charms/knative-serving/constraints.txt
+++ b/charms/knative-serving/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"


### PR DESCRIPTION
Due to python/importlib_metadata#516, we need to set up constaints
to the `setuptools-scm` to avoid install loops for these charms dependencies,
as recommended by the charmcraft team (see https://github.com/canonical/charmcraft/issues/2259#issuecomment-2842766428).

Fixes #320
