### PR TITLE
feat: Add `job-sink` key to `default-custom-images.json`

### DIFF
--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -16,6 +16,7 @@ options:
       eventing-webhook/eventing-webhook: ''
       imc-controller/controller: ''
       imc-dispatcher/dispatcher: ''
+      job-sink/job-sink: ''
       mt-broker-controller/mt-broker-controller: ''
       mt-broker-filter/filter: ''
       mt-broker-ingress/ingress: ''

--- a/charms/knative-eventing/src/default-custom-images.json
+++ b/charms/knative-eventing/src/default-custom-images.json
@@ -3,7 +3,7 @@
     "eventing-webhook/eventing-webhook": "charmedkubeflow/knative-eventing-webhook:1.16.1-41d35c3",
     "imc-controller/controller": "charmedkubeflow/knative-eventing-channel-controller:1.16.1-a297268",
     "imc-dispatcher/dispatcher": "charmedkubeflow/knative-eventing-channel-dispatcher:1.16.1-ada58f5",
-	"job-sink/job-sink": "gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:976690cda1ced05bc4714011d13baa1fc1bfe50a32b6ea27578e5d8a0300a53c",
+    "job-sink/job-sink": "gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:976690cda1ced05bc4714011d13baa1fc1bfe50a32b6ea27578e5d8a0300a53c",
     "mt-broker-controller/mt-broker-controller": "charmedkubeflow/knative-eventing-mtchannel-broker:1.16.1-b727068",
     "mt-broker-filter/filter": "charmedkubeflow/knative-eventing-broker-filter:1.16.1-38d9fc1",
     "mt-broker-ingress/ingress": "charmedkubeflow/knative-eventing-broker-ingress:1.16.1-f046888",

--- a/charms/knative-eventing/src/default-custom-images.json
+++ b/charms/knative-eventing/src/default-custom-images.json
@@ -3,6 +3,7 @@
     "eventing-webhook/eventing-webhook": "charmedkubeflow/knative-eventing-webhook:1.16.1-41d35c3",
     "imc-controller/controller": "charmedkubeflow/knative-eventing-channel-controller:1.16.1-a297268",
     "imc-dispatcher/dispatcher": "charmedkubeflow/knative-eventing-channel-dispatcher:1.16.1-ada58f5",
+	"job-sink/job-sink": "gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:3e5270924afeeccc8dfe31142a1c7f7e3ec3489df11b4c81f69f352a788ad207",
     "mt-broker-controller/mt-broker-controller": "charmedkubeflow/knative-eventing-mtchannel-broker:1.16.1-b727068",
     "mt-broker-filter/filter": "charmedkubeflow/knative-eventing-broker-filter:1.16.1-38d9fc1",
     "mt-broker-ingress/ingress": "charmedkubeflow/knative-eventing-broker-ingress:1.16.1-f046888",

--- a/charms/knative-eventing/src/default-custom-images.json
+++ b/charms/knative-eventing/src/default-custom-images.json
@@ -3,7 +3,7 @@
     "eventing-webhook/eventing-webhook": "charmedkubeflow/knative-eventing-webhook:1.16.1-41d35c3",
     "imc-controller/controller": "charmedkubeflow/knative-eventing-channel-controller:1.16.1-a297268",
     "imc-dispatcher/dispatcher": "charmedkubeflow/knative-eventing-channel-dispatcher:1.16.1-ada58f5",
-	"job-sink/job-sink": "gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:3e5270924afeeccc8dfe31142a1c7f7e3ec3489df11b4c81f69f352a788ad207",
+	"job-sink/job-sink": "gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:976690cda1ced05bc4714011d13baa1fc1bfe50a32b6ea27578e5d8a0300a53c",
     "mt-broker-controller/mt-broker-controller": "charmedkubeflow/knative-eventing-mtchannel-broker:1.16.1-b727068",
     "mt-broker-filter/filter": "charmedkubeflow/knative-eventing-broker-filter:1.16.1-38d9fc1",
     "mt-broker-ingress/ingress": "charmedkubeflow/knative-eventing-broker-ingress:1.16.1-f046888",


### PR DESCRIPTION
Ref: #327

This PR adds the `job-sink/job-sink` image to the default images in `default-custom-images.json`. This means that users can potentially change the default image deployed by replacing the image with the one they want

To test:
- Deploy the 3 knative charms (with trust)
- Replace the value of the `job-sink` key in `default-custom-images.json` with a different image, for example: `gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:3e5270924afeeccc8dfe31142a1c7f7e3ec3489df11b4c81f69f352a788ad207`. A
- Refresh the charm with `juju refresh knative-eventing --channel=latest/edge/pr-328` 
- Describe the respective deployment with `kubectl describe deploy -n knative-eventing job-sink`
- You should see the new image in the `job-sink` container.

This is needed for the rock integration task in #327.

