### PR TITLE
feat: Integrate job-sink rock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.0
     with:
       path-to-charm-directory: ${{ matrix.charm }}
-      cache: false
+      cache: true
 
   integration:
     name: Integration tests

--- a/charms/knative-eventing/constraints.txt
+++ b/charms/knative-eventing/constraints.txt
@@ -1,1 +1,4 @@
 setuptools_scm < 8.2.0; python_version < "3.10"
+# Pinned due to https://github.com/canonical/bundle-kubeflow/issues/1267
+maturin < 1.8.4; python_version <= "3.8"
+setuptools-rust < 1.11; python_version <= "3.8"

--- a/charms/knative-eventing/src/default-custom-images.json
+++ b/charms/knative-eventing/src/default-custom-images.json
@@ -3,7 +3,7 @@
     "eventing-webhook/eventing-webhook": "charmedkubeflow/knative-eventing-webhook:1.16.1-41d35c3",
     "imc-controller/controller": "charmedkubeflow/knative-eventing-channel-controller:1.16.1-a297268",
     "imc-dispatcher/dispatcher": "charmedkubeflow/knative-eventing-channel-dispatcher:1.16.1-ada58f5",
-    "job-sink/job-sink": "gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:976690cda1ced05bc4714011d13baa1fc1bfe50a32b6ea27578e5d8a0300a53c",
+    "job-sink/job-sink": "charmedkubeflow/knative-eventing-job-sink:1.16.1-1c33b95",
     "mt-broker-controller/mt-broker-controller": "charmedkubeflow/knative-eventing-mtchannel-broker:1.16.1-b727068",
     "mt-broker-filter/filter": "charmedkubeflow/knative-eventing-broker-filter:1.16.1-38d9fc1",
     "mt-broker-ingress/ingress": "charmedkubeflow/knative-eventing-broker-ingress:1.16.1-f046888",


### PR DESCRIPTION
Closes #327 

This PR replaces the upstream image for `job-sink` with the rock published in [the following action](https://github.com/canonical/knative-rocks/actions/runs/15205511310/job/42767604549).

Note that we're also re-enabling `cache` in the CI which will use the cached charms from `charmcraftcache-hub`.

## Test
First, refresh the `knative-eventing` charm with the proper channel:
```
juju refresh knative-eventing --channel=latest/edge/pr-330
```
Then I followed the [integration example](https://github.com/canonical/knative-operators?tab=readme-ov-file#integration-example) in the `README.md` to create a service and tried to curl it with the appropriate headers. I got the same results using both the upstream image and the rock:
```
curl -i http://cloudevents-player.default.${LOADBALANCER_IP}.nip.io -H "Content-Type: application/json" -H "Ce-Id: 123456789" -H "Ce-Specversion: 1.0" -H "Ce-Type: some-type" -H "Ce-Source: command-line" -d '{"msg":"Hello CloudEvents!"}'
HTTP/1.1 302 Found
location: /dex/auth?client_id=authservice-oidc&redirect_uri=%2Fauthservice%2Foidc%2Fcallback&response_type=code&scope=openid+profile+email+groups&state=MTc0ODM0OTg4MnxOd3dBTkZCSFVUWlVWVTh6U0ZaTlNGQk1WRnBLVDBzMVYwbFlSMEUzVVVWV1JESlhNMWRLUVVVMlREWlhRVFpUVUU4eVVqZFVNMEU9fGN5y2OhI5DNBm9HSbgHtPXKWgjMUh_0v-HYP7cJaTRL
set-cookie: oidc_state_csrf=MTc0ODM0OTg4MnxOd3dBTkZCSFVUWlVWVTh6U0ZaTlNGQk1WRnBLVDBzMVYwbFlSMEUzVVVWV1JESlhNMWRLUVVVMlREWlhRVFpUVUU4eVVqZFVNMEU9fGN5y2OhI5DNBm9HSbgHtPXKWgjMUh_0v-HYP7cJaTRL; Path=/; Expires=Tue, 16 Nov 2055 13:38:11 GMT; Max-Age=1200000000000
date: Tue, 27 May 2025 12:44:42 GMT
x-envoy-upstream-service-time: 4
server: istio-envoy
content-length: 0
```
