### PR TITLE
chore: Pin charm base to 24.04 in Terraform module and `release-charm` actions

### DIFF
--- a/charms/knative-eventing/terraform/README.md
+++ b/charms/knative-eventing/terraform/README.md
@@ -13,7 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
-| `base`| string | Application base | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/knative-eventing/terraform/README.md
+++ b/charms/knative-eventing/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Application base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/knative-eventing/terraform/main.tf
+++ b/charms/knative-eventing/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "knative_eventing" {
   charm {
     name     = "knative-eventing"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/knative-eventing/terraform/variables.tf
+++ b/charms/knative-eventing/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "app_name" {
 }
 
 variable "base" {
-  description = "Application base"
+  description = "Charm base"
   type        = string
   default     = "ubuntu@24.04"
 }

--- a/charms/knative-eventing/terraform/variables.tf
+++ b/charms/knative-eventing/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "knative-eventing"
 }
 
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/knative-operator/terraform/README.md
+++ b/charms/knative-operator/terraform/README.md
@@ -13,7 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
-| `base`| string | Application base | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/knative-operator/terraform/README.md
+++ b/charms/knative-operator/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Application base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/knative-operator/terraform/main.tf
+++ b/charms/knative-operator/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "knative_operator" {
   charm {
     name     = "knative-operator"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/knative-operator/terraform/variables.tf
+++ b/charms/knative-operator/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "app_name" {
 }
 
 variable "base" {
-  description = "Application base"
+  description = "Charm base"
   type        = string
   default     = "ubuntu@24.04"
 }

--- a/charms/knative-operator/terraform/variables.tf
+++ b/charms/knative-operator/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "knative-operator"
 }
 
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/knative-serving/terraform/README.md
+++ b/charms/knative-serving/terraform/README.md
@@ -13,7 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
-| `base`| string | Application base | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/knative-serving/terraform/README.md
+++ b/charms/knative-serving/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Application base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/knative-serving/terraform/main.tf
+++ b/charms/knative-serving/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "knative_serving" {
   charm {
     name     = "knative-serving"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/knative-serving/terraform/variables.tf
+++ b/charms/knative-serving/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "app_name" {
 }
 
 variable "base" {
-  description = "Application base"
+  description = "Charm base"
   type        = string
   default     = "ubuntu@24.04"
 }

--- a/charms/knative-serving/terraform/variables.tf
+++ b/charms/knative-serving/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "knative-serving"
 }
 
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1347

This PR:
- Updates the default base in the Terraform modules to `24.04`.
- Pins the base in the `release-charm` action to `24.04`, to override the default value of `20.04`
