### PR TITLE
chore: Pin charm base to 24.04 in Terraform modules

### DIFF
--- a/charms/knative-eventing/terraform/README.md
+++ b/charms/knative-eventing/terraform/README.md
@@ -13,7 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
-| `base`| string | Application base | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/knative-eventing/terraform/variables.tf
+++ b/charms/knative-eventing/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "app_name" {
 }
 
 variable "base" {
-  description = "Application base"
+  description = "Charm base"
   type        = string
   default     = "ubuntu@24.04"
 }

--- a/charms/knative-operator/terraform/README.md
+++ b/charms/knative-operator/terraform/README.md
@@ -13,7 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
-| `base`| string | Application base | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/knative-operator/terraform/variables.tf
+++ b/charms/knative-operator/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "app_name" {
 }
 
 variable "base" {
-  description = "Application base"
+  description = "Charm base"
   type        = string
   default     = "ubuntu@24.04"
 }

--- a/charms/knative-serving/terraform/README.md
+++ b/charms/knative-serving/terraform/README.md
@@ -13,7 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
-| `base`| string | Application base | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/knative-serving/terraform/variables.tf
+++ b/charms/knative-serving/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "app_name" {
 }
 
 variable "base" {
-  description = "Application base"
+  description = "Charm base"
   type        = string
   default     = "ubuntu@24.04"
 }


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1347

This PR is a backport of #381. Since `base` was already added to this track in #343, this backport simply changes the name used to align with our other repositories.