### PR TITLE
chore(backport): pin Juju provider for Terraform (#385)

### DIFF
--- a/charms/knative-eventing/terraform/versions.tf
+++ b/charms/knative-eventing/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }

--- a/charms/knative-operator/terraform/versions.tf
+++ b/charms/knative-operator/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }

--- a/charms/knative-serving/terraform/versions.tf
+++ b/charms/knative-serving/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
Backports #385 to unblock terraform checks in `track/1.16` branch, ref https://github.com/canonical/bundle-kubeflow/issues/1353