### PR TITLE
(backport) fix: remove namespace configs for serving and eventing charms (#356)

### DIFF
--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -6,10 +6,6 @@ options:
     default: "1.16.0"
     description: Version of knative-eventing component.
     type: string
-  namespace:
-    default: ""
-    description: The namespace to deploy Eventing to. This namespace cannot also contain another Knative Serving or Eventing instance. This configuration is required.
-    type: string
   custom_images:
     default: |
       eventing-controller/eventing-controller: ''

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -6,10 +6,6 @@ options:
     default: "1.16.0"
     description: Version of knative-serving component.
     type: string
-  namespace:
-    default: ""
-    description: The namespace to deploy Eventing to. This namespace cannot also contain another Knative Serving or Eventing instance. This configuration is required.
-    type: string
   domain.name:
     default: "10.64.140.43.nip.io"
     description: The domain name used for all fully-qualified route names shown

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -141,7 +141,6 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest, request):
         knative_serving,
         application_name="knative-serving",
         config={
-            "namespace": KNATIVE_SERVING_NAMESPACE,
             "istio.gateway.namespace": ops_test.model_name,
         },
         trust=True,
@@ -150,7 +149,6 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest, request):
     await ops_test.model.deploy(
         knative_eventing,
         application_name="knative-eventing",
-        config={"namespace": KNATIVE_EVENTING_NAMESPACE},
         trust=True,
     )
 

--- a/tests/test_cos_integration.py
+++ b/tests/test_cos_integration.py
@@ -66,7 +66,6 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest, request):
         knative_serving,
         application_name="knative-serving",
         config={
-            "namespace": f"{ops_test.model_name}-serving",
             "istio.gateway.namespace": ops_test.model_name,
         },
         trust=True,
@@ -75,7 +74,6 @@ async def test_build_deploy_knative_charms(ops_test: OpsTest, request):
     await ops_test.model.deploy(
         knative_eventing,
         application_name="knative-eventing",
-        config={"namespace": f"{ops_test.model_name}-eventing"},
         trust=True,
     )
 


### PR DESCRIPTION
* fix: remove namespace config for knative-eventing charm
* fix: use constant for knative-eventing namespace
* fix: remove namespace config for knative-serving charm
* update integration tests