### PR TITLE
fix: re-introduce namespace config as dummy with deprecation notice

### DIFF
--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -6,6 +6,10 @@ options:
     default: "1.16.0"
     description: Version of knative-eventing component.
     type: string
+  namespace:
+    default: ""
+    description: "DEPRECATED: This option is deprecated and does not perform any function. It is retained only for backwards compatibility and will be removed in a future release."
+    type: string
   custom_images:
     default: |
       eventing-controller/eventing-controller: ''

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -6,6 +6,10 @@ options:
     default: "1.16.0"
     description: Version of knative-serving component.
     type: string
+  namespace:
+    default: ""
+    description: "DEPRECATED: This option is deprecated and does not perform any function. It is retained only for backwards compatibility and will be removed in a future release."
+    type: string
   domain.name:
     default: "10.64.140.43.nip.io"
     description: The domain name used for all fully-qualified route names shown


### PR DESCRIPTION
Follow-up for #356 to maintain backwards compatibility in our `track/1.10` solution

This pull request introduces a deprecation notice for the `namespace` configuration option in both the `knative-eventing` and `knative-serving` charms. The option is now marked as deprecated, does not perform any function, and is retained only for backwards compatibility.